### PR TITLE
add pthread dependency for protobuf

### DIFF
--- a/cli/meson.build
+++ b/cli/meson.build
@@ -1,5 +1,6 @@
 dependencies = []
 dependencies += libyanet_protobuf_dep
+dependencies += dependency('threads')
 
 sources = files('src/config.cpp',
                 'src/main.cpp')

--- a/common/proto/meson.build
+++ b/common/proto/meson.build
@@ -1,5 +1,6 @@
 dependencies = []
 dependencies += dependency('protobuf', static: true)
+dependencies += dependency('threads')
 
 proto_sources = ['meta.proto',
                  'controlplane.proto']


### PR DESCRIPTION
add pthread dependency for resolve `std::system_error` error in protobuf.

```
$ yanet-cli balancer real any
terminate called after throwing an instance of 'std::system_error'
  what():  Unknown error -1
Aborted
```