### PR TITLE
GRE support naming refactoring

### DIFF
--- a/common/balancer.h
+++ b/common/balancer.h
@@ -5,21 +5,21 @@
 namespace balancer
 {
 
-enum class tunnel : uint8_t
+enum class forwarding_method : uint8_t
 {
 	ipip,  // in services.conf it means lvs_method: TUN
 	gre,
 };
 
-constexpr const char* to_string(const tunnel& tunnel)
+constexpr const char* to_string(const forwarding_method& forwarding_method)
 {
-	switch (tunnel)
+	switch (forwarding_method)
 	{
-		case tunnel::ipip:
+		case forwarding_method::ipip:
 		{
 			return "ipip";
 		}
-		case tunnel::gre:
+		case forwarding_method::gre:
 		{
 			return "gre";
 		}

--- a/common/controlplaneconfig.h
+++ b/common/controlplaneconfig.h
@@ -309,7 +309,7 @@ using service_t = std::tuple<balancer_service_id_t,
                              std::optional<std::string>, ///< version
                              ::balancer::scheduler,
                              ::balancer::scheduler_params,
-							 ::balancer::tunnel,
+                             ::balancer::forwarding_method,
                              uint8_t, ///< flags: mss_fix|ops
                              std::vector<real_t>>;
 

--- a/common/idp.h
+++ b/common/idp.h
@@ -261,7 +261,7 @@ namespace updateGlobalBase
 					   uint8_t, ///< flags
 					   tCounterId, ///< size 4
 					   balancer::scheduler,
-					   balancer::tunnel, // tunneling method (default ipip)
+					   balancer::forwarding_method, // tunneling method (default ipip)
 		                           uint32_t, /// default_wlc_power
 		                           uint32_t, ///< real_start
 		                           uint32_t>; ///< real_size

--- a/controlplane/balancer.cpp
+++ b/controlplane/balancer.cpp
@@ -224,7 +224,7 @@ void balancer_t::reload(const controlplane::base_t& base_prev,
 
 	for (const auto& [module_name, balancer] : base_prev.balancers)
 	{
-		for (const auto& [service_id, virtual_ip, proto, virtual_port, version, scheduler, scheduler_params, tunnel, flags, reals] : balancer.services)
+		for (const auto& [service_id, virtual_ip, proto, virtual_port, version, scheduler, scheduler_params, forwarding_method, flags, reals] : balancer.services)
 		{
 			(void)service_id;
 			(void)version;
@@ -232,7 +232,7 @@ void balancer_t::reload(const controlplane::base_t& base_prev,
 			(void)scheduler_params;
 			(void)reals;
 			(void)flags;
-			(void)tunnel;
+			(void)forwarding_method;
 
 			service_counters.remove({module_name, {virtual_ip, proto, virtual_port}});
 
@@ -256,14 +256,14 @@ void balancer_t::reload(const controlplane::base_t& base_prev,
 	{
 		std::unordered_set<std::tuple<common::ip_address_t, uint16_t, uint8_t>> vip_vport_proto;
 
-		for (const auto& [service_id, virtual_ip, proto, virtual_port, version, scheduler, scheduler_params, tunnel, flags, reals] : balancer.services)
+		for (const auto& [service_id, virtual_ip, proto, virtual_port, version, scheduler, scheduler_params, forwarding_method, flags, reals] : balancer.services)
 		{
 			(void)service_id;
 			(void)version;
 			(void)scheduler;
 			(void)scheduler_params;
 			(void)flags;
-			(void)tunnel;
+			(void)forwarding_method;
 
 			service_counters.insert({module_name, {virtual_ip, proto, virtual_port}});
 
@@ -602,11 +602,11 @@ void balancer_t::update_service(const balancer::generation_config_t& generation_
 		uint64_t services_reals_enabled_count = 0;
 		uint64_t services_reals_count = 0;
 
-		for (const auto& [service_id, virtual_ip, proto, virtual_port, version, scheduler, scheduler_params, tunnel, flags, reals] : balancer.services)
+		for (const auto& [service_id, virtual_ip, proto, virtual_port, version, scheduler, scheduler_params, forwarding_method, flags, reals] : balancer.services)
 		{
 			(void) flags;
 			(void) scheduler_params;
-			(void) tunnel;
+			(void) forwarding_method;
 
 			if (service_id >= YANET_CONFIG_BALANCER_SERVICES_SIZE)
 			{
@@ -687,7 +687,7 @@ void balancer_t::compile(common::idp::updateGlobalBase::request& globalbase,
 
 	for (const auto& [module_name, balancer] : generation_config.config_balancers)
 	{
-		for (const auto& [service_id, virtual_ip, proto, virtual_port, version, scheduler, scheduler_params, tunnel, flags, reals] : balancer.services)
+		for (const auto& [service_id, virtual_ip, proto, virtual_port, version, scheduler, scheduler_params, forwarding_method, flags, reals] : balancer.services)
 		{
 			(void) scheduler_params;
 			(void) version;
@@ -734,9 +734,9 @@ void balancer_t::compile(common::idp::updateGlobalBase::request& globalbase,
 				service_id,
 				flags,
 				counter_ids[0],
-			    	scheduler,
-					tunnel,
-			    	balancer.default_wlc_power, //todo use scheduler_params.wlc_power when other services will be able to set it
+			    scheduler,
+				forwarding_method,
+			    balancer.default_wlc_power, //todo use scheduler_params.wlc_power when other services will be able to set it
 				(uint32_t)real_start,
 				(uint32_t)(req_reals.size() - real_start)});
 		}
@@ -757,13 +757,13 @@ void balancer_t::flush_reals(common::idp::updateGlobalBaseBalancer::request& bal
 	for (const auto& [module_name, balancer] : generation_config.config_balancers)
 	{
 
-		for (const auto& [service_id, virtual_ip, proto, virtual_port, version, scheduler, scheduler_params, tunnel, flags, reals] : balancer.services)
+		for (const auto& [service_id, virtual_ip, proto, virtual_port, version, scheduler, scheduler_params, forwarding_method, flags, reals] : balancer.services)
 		{
 			(void)flags;
 			(void)scheduler;
 			(void)scheduler_params;
 			(void)version;
-			(void)tunnel;
+			(void)forwarding_method;
 
 			if (service_id >= YANET_CONFIG_BALANCER_SERVICES_SIZE)
 			{

--- a/controlplane/configconverter.cpp
+++ b/controlplane/configconverter.cpp
@@ -587,7 +587,7 @@ void config_converter_t::processBalancer()
 																						balancer.source_ipv4,
 		                                                                                balancer.flow});
 
-		for (const auto& [service_id, vip, proto, vport, version, scheduler, scheduler_params, tunnel, flags, reals] : balancer.services)
+		for (const auto& [service_id, vip, proto, vport, version, scheduler, scheduler_params, forwarding_method, flags, reals] : balancer.services)
 		{
 			/// @todo:
 			(void)vip;
@@ -598,7 +598,7 @@ void config_converter_t::processBalancer()
 			(void)flags;
 			(void)reals;
 			(void)version;
-			(void)tunnel;
+			(void)forwarding_method;
 
 			if (service_id >= YANET_CONFIG_BALANCER_SERVICES_SIZE)
 			{
@@ -1472,13 +1472,13 @@ void config_converter_t::acl_rules_balancer(controlplane::base::acl_t& acl,
 	auto flow = convertToFlow(nextModule);
 	auto flow_fragment = convertToFlow(nextModule, "fragment"); ///< actually drop
 
-	for (const auto& [service_id, vip, proto, vport, version, scheduler, scheduler_params, tunnel, flags, reals] : balancer.services)
+	for (const auto& [service_id, vip, proto, vport, version, scheduler, scheduler_params, forwarding_method, flags, reals] : balancer.services)
 	{
 		(void)scheduler;
 		(void)scheduler_params;
 		(void)version;
 		(void)flags;
-		(void)tunnel;
+		(void)forwarding_method;
 
 		if (reals.empty())
 		{
@@ -1553,7 +1553,7 @@ void config_converter_t::acl_rules_balancer_icmp_reply(controlplane::base::acl_t
 
 	auto flow = convertToFlow(nextModule, "icmp_reply");
 
-	for (const auto& [service_id, vip, proto, vport, version, scheduler, scheduler_params, tunnel, flags, reals] : balancer.services)
+	for (const auto& [service_id, vip, proto, vport, version, scheduler, scheduler_params, forwarding_method, flags, reals] : balancer.services)
 	{
 		(void)scheduler;
 		(void)scheduler_params;
@@ -1561,7 +1561,7 @@ void config_converter_t::acl_rules_balancer_icmp_reply(controlplane::base::acl_t
 		(void)proto;
 		(void)vport;
 		(void)version;
-		(void)tunnel;
+		(void)forwarding_method;
 
 		if (reals.empty())
 		{
@@ -1609,7 +1609,7 @@ void config_converter_t::acl_rules_balancer_icmp_forward(controlplane::base::acl
 	ranges_t icmpv6_forward_types(values_t({ICMP6_DST_UNREACH, ICMP6_TIME_EXCEEDED, ICMP6_PARAM_PROB, ICMP6_PACKET_TOO_BIG}));
 	controlplane::base::acl_rule_transport_icmpv6_t rule_icmpv6_forward(icmpv6_forward_types);
 
-	for (const auto& [service_id, vip, proto, vport, version, scheduler, scheduler_params, tunnel, flags, reals] : balancer.services)
+	for (const auto& [service_id, vip, proto, vport, version, scheduler, scheduler_params, forwarding_method, flags, reals] : balancer.services)
 	{
 		(void)scheduler;
 		(void)scheduler_params;
@@ -1617,7 +1617,7 @@ void config_converter_t::acl_rules_balancer_icmp_forward(controlplane::base::acl
 		(void)proto;
 		(void)vport;
 		(void)version;
-		(void)tunnel;
+		(void)forwarding_method;
 
 		if (reals.empty())
 		{

--- a/controlplane/configparser.cpp
+++ b/controlplane/configparser.cpp
@@ -1577,22 +1577,22 @@ void config_parser_t::loadConfig_balancer_services(controlplane::base_t& baseNex
 			throw error_result_t(eResult::invalidConfigurationFile, "unknown scheduler: " + scheduler_string);
 		}
 
-		balancer::tunnel tunnel;
+		balancer::forwarding_method forwarding_method;
 
 		if (!exist(service_json, "lvs_method"))
 		{
-			tunnel = balancer::tunnel::ipip;
+			forwarding_method = balancer::forwarding_method::ipip;
 		}
 		else
 		{
-			std::string tunnel_string = service_json["lvs_method"];
-			if (tunnel_string == "TUN")
+			std::string forwarding_method_string = service_json["lvs_method"];
+			if (forwarding_method_string == "TUN")
 			{
-				tunnel = balancer::tunnel::ipip;
+				forwarding_method = balancer::forwarding_method::ipip;
 			}
 			else
 			{
-				tunnel = balancer::tunnel::gre;
+				forwarding_method = balancer::forwarding_method::gre;
 			}
 		}
 
@@ -1650,7 +1650,7 @@ void config_parser_t::loadConfig_balancer_services(controlplane::base_t& baseNex
 		                               service_version,
 		                               scheduler,
 		                               scheduler_params,
-									   tunnel,
+									   forwarding_method,
 					       			   flags,
 		                               reals);
 

--- a/dataplane/globalbase.cpp
+++ b/dataplane/globalbase.cpp
@@ -1181,7 +1181,7 @@ eResult generation::update_balancer_services(const common::idp::updateGlobalBase
 	}
 	balancer_services_count = 0;
 
-	for (const auto& [balancer_service_id, flags, counter_id, scheduler, tunnel, default_wlc_power, real_start, real_size] : services)
+	for (const auto& [balancer_service_id, flags, counter_id, scheduler, forwarding_method, default_wlc_power, real_start, real_size] : services)
 	{
 		if (balancer_service_id >= YANET_CONFIG_BALANCER_SERVICES_SIZE)
 		{
@@ -1212,7 +1212,7 @@ eResult generation::update_balancer_services(const common::idp::updateGlobalBase
 		balancer_service.real_size = real_size;
 		balancer_service.scheduler = scheduler;
 		balancer_service.wlc_power = default_wlc_power;
-		balancer_service.tunnel = tunnel;
+		balancer_service.forwarding_method = forwarding_method;
 	}
 
 	const auto& reals = std::get<1>(request);

--- a/dataplane/type.h
+++ b/dataplane/type.h
@@ -574,7 +574,7 @@ namespace globalBase
 		uint32_t real_start;
 		uint32_t real_size;
 		::balancer::scheduler scheduler;
-		::balancer::tunnel tunnel;
+		::balancer::forwarding_method forwarding_method;
 		uint32_t wlc_power;
 	};
 

--- a/dataplane/worker.cpp
+++ b/dataplane/worker.cpp
@@ -3950,7 +3950,7 @@ inline void cWorker::balancer_tunnel(rte_mbuf* mbuf,
 
 		yanet_ipv4_checksum(ipv4Header);
 	}
-	if (service.tunnel == balancer::tunnel::gre)
+	if (service.forwarding_method == balancer::forwarding_method::gre)
 	{
 		// update data in ip headers and insert gre
 		rte_pktmbuf_prepend(mbuf, sizeof(rte_gre_hdr));


### PR DESCRIPTION
The implementation of GRE tunneling scheme introduced updates to multiple structures in yanet. Yet the naming of the fields used for forwarding method in those structures was flawed. They were called 'tunnel', and that name could have led to confusion. 
This patch renames that field to 'forwarding_method'