### PR TITLE
link_id and nexthop_ip in yanet-cli output for external systems

### DIFF
--- a/autotest/autotest.cpp
+++ b/autotest/autotest.cpp
@@ -991,6 +991,24 @@ bool tAutotest::step_rib_insert(const YAML::Node& yaml)
 				med = yaml_table["med"].as<uint32_t>();
 			}
 
+			std::vector<uint32_t> aspath;
+			if (yaml_table["aspath"].IsDefined())
+			{
+				for (const auto& yaml_aspath : yaml_table["aspath"])
+				{
+					aspath.emplace_back(yaml_aspath.as<uint32_t>());
+				}
+			}
+
+			std::set<community_t> communities;
+			if (yaml_table["communities"].IsDefined())
+			{
+				for (const auto& yaml_community : yaml_table["communities"])
+				{
+					communities.emplace(yaml_community.as<std::string>());
+				}
+			}
+
 			std::set<large_community_t> large_communities;
 			if (yaml_table["large_communities"].IsDefined())
 			{
@@ -1006,7 +1024,7 @@ bool tAutotest::step_rib_insert(const YAML::Node& yaml)
 				local_pref = yaml_table["local_pref"].as<uint32_t>();
 			}
 
-			auto& prefixes = attribute_tables[{peer, "incomplete", med, {}, {}, large_communities, local_pref}][table_name];
+			auto& prefixes = attribute_tables[{peer, "incomplete", med, aspath, communities, large_communities, local_pref}][table_name];
 
 			if (yaml_table["prefixes"].IsDefined())
 			{

--- a/common/icp.h
+++ b/common/icp.h
@@ -265,12 +265,14 @@ using response = std::tuple<std::vector<uint8_t>, ///< dregress_counters_v4 + dr
 namespace telegraf_dregress_traffic
 {
 using peer = std::tuple<bool, ///< is_ipv4
-                        std::string, ///< link_name
+                        uint32_t, ///< link_id
+                        std::string, ///< nexthop
                         uint64_t, ///< packets
                         uint64_t>;
 
 using peer_as = std::tuple<bool, ///< is_ipv4
-                           std::string, ///< link_name
+                           uint32_t, ///< link_id
+                           std::string, ///< nexthop
                            uint32_t, ///< origin_as
                            uint64_t, ///< packets
                            uint64_t>; ///< bytes

--- a/common/type.h
+++ b/common/type.h
@@ -2477,6 +2477,7 @@ using value_t = std::tuple<common::ip_address_t, ///< nexthop
 
 using counters_t = common::ctree<4, ///< ack, loss, rtt_sum, rtt_count
                                  common::community_t,
+                                 common::ip_address_t, ///< nexthop
                                  bool, ///< is_best
                                  uint32_t, ///< label
                                  uint32_t, ///< peer_as

--- a/controlplane/route.h
+++ b/controlplane/route.h
@@ -74,6 +74,7 @@ using tunnel_lookup_t = std::tuple<ip_address_t, ///< nexthop
 /// @todo: vrf
 using tunnel_counter_key_t = std::tuple<bool, ///< is_ipv4
                                         uint32_t, ///< peer_id
+                                        ip_address_t, ///< nexthop
                                         uint32_t>; ///< origin_as
 
 class generation_t

--- a/controlplane/telegraf.cpp
+++ b/controlplane/telegraf.cpp
@@ -223,7 +223,7 @@ common::icp::telegraf_dregress_traffic::response telegraf_t::telegraf_dregress_t
 		const auto counters = controlPlane->route.tunnel_counter.get_counters();
 		for (const auto& [key, value] : counters)
 		{
-			const auto& [is_ipv4, peer_id, origin_as] = key;
+			const auto& [is_ipv4, peer_id, nexthop, origin_as] = key;
 			const auto& [packets, bytes] = value;
 			(void)origin_as;
 
@@ -234,7 +234,7 @@ common::icp::telegraf_dregress_traffic::response telegraf_t::telegraf_dregress_t
 
 				if (packets > packets_prev)
 				{
-					auto& [peer_packets, peer_bytes] = route_tunnel_peer_counters[{is_ipv4, peer_id}];
+					auto& [peer_packets, peer_bytes] = route_tunnel_peer_counters[{is_ipv4, peer_id, nexthop}];
 					peer_packets += packets - packets_prev;
 					peer_bytes += bytes - bytes_prev;
 
@@ -244,7 +244,8 @@ common::icp::telegraf_dregress_traffic::response telegraf_t::telegraf_dregress_t
 						/// not fallback
 
 						response_peer_as.emplace_back(is_ipv4,
-						                              peers[peer_id],
+						                              peer_id,
+						                              nexthop.toString(),
 						                              origin_as,
 						                              packets - packets_prev,
 						                              bytes - bytes_prev);
@@ -255,10 +256,10 @@ common::icp::telegraf_dregress_traffic::response telegraf_t::telegraf_dregress_t
 
 		for (const auto& [key, value] : route_tunnel_peer_counters)
 		{
-			const auto& [is_ipv4, peer_id] = key;
+			const auto& [is_ipv4, peer_id, nexthop] = key;
 			const auto& [packets, bytes] = value;
 
-			response_peer.emplace_back(is_ipv4, peers[peer_id], packets, bytes);
+			response_peer.emplace_back(is_ipv4, peer_id, nexthop.toString(), packets, bytes);
 		}
 
 		dregress_traffic_counters_prev = counters;

--- a/controlplane/telegraf.h
+++ b/controlplane/telegraf.h
@@ -90,6 +90,6 @@ protected:
 
 	std::map<tCoreId, common::idp::getOtherStats::worker> prevWorkers;
 
-	std::map<std::tuple<bool, uint32_t>, std::array<common::uint64, 2>> route_tunnel_peer_counters; ///< @todo: gc
+	std::map<std::tuple<bool, uint32_t, common::ip_address_t>, std::array<common::uint64, 2>> route_tunnel_peer_counters; ///< @todo: gc
 	std::map<route::tunnel_counter_key_t, std::array<uint64_t, 2>> dregress_traffic_counters_prev;
 };

--- a/dataplane/common.h
+++ b/dataplane/common.h
@@ -46,6 +46,7 @@
 
 #define YANET_DREGRESS_FLAG_FIN ((uint8_t)(1u << 0))
 #define YANET_DREGRESS_FLAG_IS_BEST ((uint8_t)(1u << 1))
+#define YANET_DREGRESS_FLAG_NH_IS_IPV4 ((uint8_t)(1u << 2))
 
 #define YANET_BALANCER_FLAG_ENABLED ((uint8_t)(1u << 0))
 #define YANET_BALANCER_FLAG_DST_IPV6 ((uint8_t)(1u << 1))


### PR DESCRIPTION
link_id and nexthop fields of 'telegraf dregress' and 'telegraf peer' are necessary for correct peer_link matching