### PR TITLE
Increased the version of bison to 3.3 for Ubuntu 18.40 build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -78,6 +78,19 @@ jobs:
           meson compile -C build
       - run: meson install -C build
 
+  build-ubuntu1804:
+    name: build (Ubuntu 18.04)
+    needs: build-image-builder
+    runs-on: ubuntu-latest
+    container:
+      image: yanetplatform/builder_ubuntu18.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          meson setup --prefix=/target -Dstrip=true build
+          meson compile -C build
+      - run: meson install -C build
+
 
   unittest:
     needs: build-unittest

--- a/docker/builder_ubuntu18.04.Dockerfile
+++ b/docker/builder_ubuntu18.04.Dockerfile
@@ -74,6 +74,20 @@ RUN make install && \
     ldconfig
 
 
+# bison
+ENV BISON_VERSION 3.3.2
+
+WORKDIR /project
+RUN curl http://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION}.tar.gz -o bison.tar.gz
+RUN mkdir bison && \
+    tar -xf bison.tar.gz -C bison --strip-components=1
+
+WORKDIR /project/bison
+RUN ./configure --prefix=/usr
+RUN make -j
+RUN make install
+
+
 WORKDIR /project
 RUN rm -rf *
 
@@ -82,7 +96,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libsystemd-dev \
     libyaml-cpp-dev \
     libgtest-dev \
-    bison \
     flex \
     libfl-dev \
     netbase \

--- a/libfwparser/fw_parser.y
+++ b/libfwparser/fw_parser.y
@@ -1,5 +1,5 @@
-// require bison version 3.2+
-%require "3.2"
+// require bison version 3.3+
+%require "3.3"
 
 // generate C++ source code
 %language "C++"


### PR DESCRIPTION
Minimal version of bison for libfwparser is 3.3. In Ubuntu 18.04 repo is 3.0. Build it from source and push to yanetplatform/builder_ubuntu18.04 image.
Also add build release for Ubuntu 18.04 in CI.