### PR TITLE
Add settings for the hash table of the load balancer session states in `dataplane.conf`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build_*
 __pycache__
 report/
 .*
+compile_commands.json

--- a/dataplane/controlplane.cpp
+++ b/dataplane/controlplane.cpp
@@ -1024,7 +1024,7 @@ common::idp::balancer_connection::response cControlPlane::balancer_connection(co
 
 			const auto& base = worker_gc->bases[worker_gc->local_base_id & 1];
 
-			for (auto iter : worker_gc->base_permanently.globalBaseAtomic->balancer_state.range(offset, 64))
+			for (auto iter : worker_gc->base_permanently.globalBaseAtomic->updater.balancer_state.range(offset, 64))
 			{
 				if (iter.is_valid())
 				{

--- a/dataplane/dataplane.h
+++ b/dataplane/dataplane.h
@@ -57,6 +57,8 @@ enum class eConfigType
 	master_mempool_size,
 	nat64stateful_states_size,
 	kernel_interface_queue_size,
+	balancer_state_ttl,
+	balancer_state_ht_size,
 };
 
 struct tDataPlaneConfig

--- a/dataplane/globalbase.cpp
+++ b/dataplane/globalbase.cpp
@@ -1,7 +1,5 @@
 #include <memory.h>
 
-#include <string>
-
 #include <rte_errno.h>
 
 #include "common.h"
@@ -1270,7 +1268,7 @@ eResult generation::update_balancer_services(const common::idp::updateGlobalBase
 			return eResult::invalidId;
 		}
 
-		if (counter_id + (tCounterId)balancer::service_counter::size > YANET_CONFIG_COUNTERS_SIZE)
+		if (counter_id + (tCounterId)::balancer::service_counter::size > YANET_CONFIG_COUNTERS_SIZE)
 		{
 			YADECAP_LOG_ERROR("invalid counter_id: '%u'\n", counter_id);
 			return eResult::invalidId;
@@ -1334,7 +1332,7 @@ eResult generation::update_balancer_services(const common::idp::updateGlobalBase
 
 		auto& real_unordered = balancer_reals[real_id];
 
-		if (counter_id + (tCounterId)balancer::real_counter::size > YANET_CONFIG_COUNTERS_SIZE)
+		if (counter_id + (tCounterId)::balancer::real_counter::size > YANET_CONFIG_COUNTERS_SIZE)
 		{
 			YADECAP_LOG_ERROR("invalid counter_id: '%u'\n", counter_id);
 			return eResult::invalidId;
@@ -1343,7 +1341,7 @@ eResult generation::update_balancer_services(const common::idp::updateGlobalBase
 		auto addr = ipv6_address_t::convert(destination);
 		if (real_unordered.counter_id != counter_id || real_unordered.destination != addr)
 		{
-			for (tCounterId i = 0; i < (tCounterId)balancer::real_counter::size; ++i)
+			for (tCounterId i = 0; i < (tCounterId)::balancer::real_counter::size; ++i)
 			{
 				uint64_t sum_worker = 0, sum_gc = 0;
 				for (const auto& [core_id, worker] : dataPlane->workers)
@@ -1438,22 +1436,22 @@ inline uint64_t generation::count_real_connections(uint32_t counter_id)
 	for (const auto& [core_id, worker] : dataPlane->workers)
 	{
 		(void)core_id;
-		sessions_created += worker->counters[counter_id + (tCounterId)balancer::real_counter::sessions_created];
-		sessions_destroyed += worker->counters[counter_id + (tCounterId)balancer::real_counter::sessions_destroyed];
+		sessions_created += worker->counters[counter_id + (tCounterId)::balancer::real_counter::sessions_created];
+		sessions_destroyed += worker->counters[counter_id + (tCounterId)::balancer::real_counter::sessions_destroyed];
 	}
-	sessions_created -= dataPlane->globalBaseAtomics[socketId]->counter_shifts[counter_id + (tCounterId)balancer::real_counter::sessions_created];
-	sessions_destroyed -= dataPlane->globalBaseAtomics[socketId]->counter_shifts[counter_id + (tCounterId)balancer::real_counter::sessions_destroyed];
+	sessions_created -= dataPlane->globalBaseAtomics[socketId]->counter_shifts[counter_id + (tCounterId)::balancer::real_counter::sessions_created];
+	sessions_destroyed -= dataPlane->globalBaseAtomics[socketId]->counter_shifts[counter_id + (tCounterId)::balancer::real_counter::sessions_destroyed];
 
 	uint64_t sessions_created_gc = 0;
 	uint64_t sessions_destroyed_gc = 0;
 	for (const auto& [node_id, worker_gc] : dataPlane->worker_gcs)
 	{
 		(void)node_id;
-		sessions_created_gc += worker_gc->counters[counter_id + (tCounterId)balancer::gc_real_counter::sessions_created];
-		sessions_destroyed_gc += worker_gc->counters[counter_id + (tCounterId)balancer::gc_real_counter::sessions_destroyed];
+		sessions_created_gc += worker_gc->counters[counter_id + (tCounterId)::balancer::gc_real_counter::sessions_created];
+		sessions_destroyed_gc += worker_gc->counters[counter_id + (tCounterId)::balancer::gc_real_counter::sessions_destroyed];
 	}
-	sessions_created_gc -= dataPlane->globalBaseAtomics[socketId]->gc_counter_shifts[counter_id + (tCounterId)balancer::gc_real_counter::sessions_created];
-	sessions_destroyed_gc -= dataPlane->globalBaseAtomics[socketId]->gc_counter_shifts[counter_id + (tCounterId)balancer::gc_real_counter::sessions_destroyed];
+	sessions_created_gc -= dataPlane->globalBaseAtomics[socketId]->gc_counter_shifts[counter_id + (tCounterId)::balancer::gc_real_counter::sessions_created];
+	sessions_destroyed_gc -= dataPlane->globalBaseAtomics[socketId]->gc_counter_shifts[counter_id + (tCounterId)::balancer::gc_real_counter::sessions_destroyed];
 	return (sessions_created - sessions_destroyed + sessions_created_gc - sessions_destroyed_gc) / dataPlane->numaNodesInUse;
 }
 

--- a/dataplane/globalbase.h
+++ b/dataplane/globalbase.h
@@ -76,6 +76,11 @@ using lan_ht = hashtable_mod_spinlock_dynamic<nat64stateful_lan_key, nat64statef
 using wan_ht = hashtable_mod_spinlock_dynamic<nat64stateful_wan_key, nat64stateful_wan_value, 16>;
 }
 
+namespace balancer
+{
+using state_ht = hashtable_mod_spinlock_dynamic<balancer_state_key_t, balancer_state_value_t, 16>;
+}
+
 class atomic
 {
 public:
@@ -92,6 +97,7 @@ public: ///< @todo
 		acl::ipv6_states_ht::updater fw6_state;
 		nat64stateful::lan_ht::updater nat64stateful_lan_state;
 		nat64stateful::wan_ht::updater nat64stateful_wan_state;
+		balancer::state_ht::updater balancer_state;
 	} updater;
 
 	hashtable_gc_t balancer_state_gc;
@@ -114,12 +120,7 @@ public: ///< @todo
 	acl::ipv6_states_ht* fw6_state;
 	nat64stateful::lan_ht* nat64stateful_lan_state;
 	nat64stateful::wan_ht* nat64stateful_wan_state;
-
-	hashtable_mod_spinlock<balancer_state_key_t,
-	                       balancer_state_value_t,
-	                       YANET_CONFIG_BALANCER_STATE_HT_SIZE,
-	                       16>
-	        balancer_state;
+	balancer::state_ht* balancer_state;
 };
 
 //

--- a/dataplane/report.cpp
+++ b/dataplane/report.cpp
@@ -410,7 +410,7 @@ nlohmann::json cReport::convertWorkerGC(const worker_gc_t* worker)
 	const auto& base = worker->bases[worker->current_base_id];
 	json["base"]["globalBase"]["pointer"] = pointerToHex(base.globalBase);
 
-	json["balancer_state"] = convertHashtable(worker->base_permanently.globalBaseAtomic->balancer_state, worker->balancer_state_stats);
+	worker->base_permanently.globalBaseAtomic->updater.balancer_state.report(json["balancer_state"]);
 
 	return json;
 }

--- a/dataplane/worker.cpp
+++ b/dataplane/worker.cpp
@@ -2,7 +2,6 @@
 #include <netinet/ip_icmp.h>
 
 #include <string>
-#include <thread>
 
 #include <rte_errno.h>
 #include <rte_ethdev.h>
@@ -3924,7 +3923,7 @@ inline void cWorker::balancer_handle()
 
 		dataplane::globalBase::balancer_state_value_t* value;
 		dataplane::spinlock_nonrecursive_t* locker;
-		const uint32_t hash = basePermanently.globalBaseAtomic->balancer_state.lookup(key, value, locker);
+		const uint32_t hash = basePermanently.globalBaseAtomic->balancer_state->lookup(key, value, locker);
 		bool rescheduleReal = false;
 		if (value)
 		{
@@ -3999,7 +3998,7 @@ inline void cWorker::balancer_handle()
 					/// counter_id:
 					///   0 - insert failed
 					///   1 - insert done
-					uint32_t counter_id = basePermanently.globalBaseAtomic->balancer_state.insert(hash, key, value);
+					uint32_t counter_id = basePermanently.globalBaseAtomic->balancer_state->insert(hash, key, value);
 					counters[(uint32_t)common::globalBase::static_counter_type::balancer_state + counter_id]++;
 					if (counter_id)
 					{
@@ -4522,7 +4521,7 @@ inline void cWorker::balancer_icmp_forward_handle()
 
 		dataplane::globalBase::balancer_state_value_t* value;
 		dataplane::spinlock_nonrecursive_t* locker;
-		basePermanently.globalBaseAtomic->balancer_state.lookup(key, value, locker);
+		basePermanently.globalBaseAtomic->balancer_state->lookup(key, value, locker);
 
 		if (value)
 		{

--- a/dataplane/worker_gc.h
+++ b/dataplane/worker_gc.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <list>
 #include <mutex>
 #include <queue>
 
@@ -9,6 +8,7 @@
 
 #include "common/generation.h"
 #include "common/idp.h"
+#include "hashtable.h"
 
 class worker_gc_t
 {
@@ -60,6 +60,8 @@ public:
 	dataplane::base::permanently base_permanently;
 	common::worker_gc::stats_t stats;
 	dataplane::base::generation bases[2];
+
+	uint16_t balancer_state_ttl;
 
 	YADECAP_CACHE_ALIGNED(align1);
 


### PR DESCRIPTION
Adding two new parameters to the `dataplane.conf`'s `configValues` section:
`balancer_state_ttl`: session lifetime in the table after passing the last network packet;
`balancer_state_ht_size`: size of the sessions hash table; the value must be a power of `2` and at least `16`.