### PR TITLE
fix: collect eth stats under the mutex

### DIFF
--- a/dataplane/controlplane.cpp
+++ b/dataplane/controlplane.cpp
@@ -423,16 +423,15 @@ common::idp::get_dregress_counters::response cControlPlane::get_dregress_counter
 
 common::idp::get_ports_stats::response cControlPlane::get_ports_stats()
 {
-	/// unsafe
-
 	common::idp::get_ports_stats::response response;
+
+	std::lock_guard<std::mutex> guard(mutex);
 
 	for (const auto& [portId, port] : dataPlane->ports)
 	{
 		(void)port;
 
 		rte_eth_stats stats;
-		memset(&stats, 0, sizeof(stats));
 		rte_eth_stats_get(portId, &stats);
 
 		uint64_t physicalPort_egress_drops = 0;
@@ -636,9 +635,9 @@ common::idp::getAclCounters::response cControlPlane::getAclCounters()
 
 common::idp::getPortStatsEx::response cControlPlane::getPortStatsEx()
 {
-	std::lock_guard<std::mutex> guard(mutex);
-
 	common::idp::getPortStatsEx::response response;
+
+	std::lock_guard<std::mutex> guard(mutex);
 
 	for (const auto& portIter : dataPlane->ports)
 	{


### PR DESCRIPTION
DPDK's interface for collecting device statistics is not thread-safe. However, we can easily achieve a situation when multiple threads try to collect stats for its purposes, because, for example, we spawn a separate thread for each CP-DP connection. Such thread-unsafety results in device statistics skewness, and maybe other more serious bugs. Things get even worse if we try to trace the call graph from DPDK to the drivers.

For example, both `rte_eth_stats_get` and `rte_eth_xstats_get` are end with calling `ice_stats_get` for ICE driver, which is also not thread-safe.

As we have these calls scattered across the entire dataplane - some of them under the "global" mutex, some are not - we have two possible ways how to solve the issue above. The first one is to protect all branches under the same mutex, but it makes the code even harder to understand. Mutext hell. The second one - is to serialize API calls, making them execute in a single thread, this is better, but requires massive code refactoring.

This PR follows the first way. Add the mutex. Pray to not be caught by deadlocks.