### PR TITLE
controlplane: remove get_mac_address(). resolve neighbor in dataplane now

### DIFF
--- a/controlplane/controlplane.cpp
+++ b/controlplane/controlplane.cpp
@@ -259,23 +259,6 @@ eResult cControlPlane::getPhysicalPortName(const tPortId& portId,
 	return eResult::invalidPortId;
 }
 
-std::optional<common::mac_address_t> cControlPlane::get_mac_address(const std::string& vrf,
-                                                                    const std::string& interface_name,
-                                                                    const common::ip_address_t& address)
-{
-	std::lock_guard mac_addresses_lock(mac_addresses_mutex);
-
-	const auto key = std::make_tuple(vrf, interface_name, address);
-
-	auto it = mac_addresses.find(key);
-	if (it == mac_addresses.end())
-	{
-		it = mac_addresses.emplace_hint(it, key, system.getMacAddress(interface_name, address));
-	}
-
-	return it->second;
-}
-
 common::icp::getPhysicalPorts::response cControlPlane::getPhysicalPorts() const
 {
 	common::icp::getPhysicalPorts::response response;

--- a/controlplane/controlplane.h
+++ b/controlplane/controlplane.h
@@ -46,7 +46,6 @@ public:
 	eResult reloadConfig();
 
 	eResult getPhysicalPortName(const tPortId& portId, std::string& name) const;
-	std::optional<common::mac_address_t> get_mac_address(const std::string& vrf, const std::string& interface_name, const common::ip_address_t& address);
 
 	template<typename T_function>
 	void register_command(const common::icp::requestType& type, const T_function& function)
@@ -196,12 +195,5 @@ private:
 	/// used only in loadConfig()
 	controlplane::base_t base;
 
-	/// @todo: move to new module
-	std::mutex mac_addresses_mutex;
-	std::map<std::tuple<std::string, ///< vrf
-	                    std::string, ///< interface_name
-	                    common::ip_address_t>, ///< neighbor
-	         std::optional<common::mac_address_t>>
-	        mac_addresses;
 	void register_service(google::protobuf::Service* service);
 };

--- a/controlplane/route.cpp
+++ b/controlplane/route.cpp
@@ -777,10 +777,6 @@ void route_t::compile_interface(common::idp::updateGlobalBase::request& globalba
 				{
 					neighbor_mac_address_v4 = *interface.static_neighbor_mac_address_v4;
 				}
-				else
-				{
-					neighbor_mac_address_v4 = controlPlane->get_mac_address(route.vrf, interface_name, *interface.neighborIPv4Address);
-				}
 			}
 
 			if (interface.neighborIPv6Address)
@@ -788,10 +784,6 @@ void route_t::compile_interface(common::idp::updateGlobalBase::request& globalba
 				if (interface.static_neighbor_mac_address_v6)
 				{
 					neighbor_mac_address_v6 = *interface.static_neighbor_mac_address_v6;
-				}
-				else
-				{
-					neighbor_mac_address_v6 = controlPlane->get_mac_address(route.vrf, interface_name, *interface.neighborIPv6Address);
 				}
 			}
 


### PR DESCRIPTION
`yanet-cli neighbor show` incorrectly print static MAC addresses