### PR TITLE
refactor: drop dataplane's report server

### DIFF
--- a/dataplane/dataplane.cpp
+++ b/dataplane/dataplane.cpp
@@ -235,12 +235,6 @@ eResult cDataPlane::init(const std::string& binaryPath,
 		return result;
 	}
 
-	result = report.init();
-	if (result != eResult::success)
-	{
-		return result;
-	}
-
 	result = controlPlane->init(config.use_kernel_interface);
 	if (result != eResult::success)
 	{
@@ -1265,7 +1259,6 @@ void cDataPlane::start()
 		timestamp_thread();
 	});
 
-	report.run();
 	bus.run();
 
 	/// run forwarding plane and control plane
@@ -1276,7 +1269,6 @@ void cDataPlane::join()
 {
 	rte_eal_mp_wait_lcore();
 
-	report.join();
 	bus.join();
 }
 

--- a/dataplane/report.h
+++ b/dataplane/report.h
@@ -1,29 +1,26 @@
 #pragma once
 
-#include <thread>
-
 #include <nlohmann/json.hpp>
-
-#include "common/result.h"
-#include "common/type.h"
 
 #include "type.h"
 
+/// Provides various reports about the current state of the dataplane in JSON format.
 class cReport
 {
 public:
-	cReport(cDataPlane* dataPlane);
+	explicit cReport(cDataPlane* dataPlane);
 
-	eResult init();
-	void run();
-	void stop();
-	void join();
-
+	/// Returns the current state of the dataplane.
+	///
+	/// This function is not marked as const, because eventually it calls DPDK
+	/// functions, which in its turn call driver's functions, which can
+	/// modify its own state.
+	///
+	/// As a result, this method itself is not thread-safe. Be careful calling
+	/// DPDK functions in multiple threads parallel with this method.
 	nlohmann::json getReport();
 
 protected:
-	void mainLoop();
-
 	nlohmann::json convertWorker(const cWorker* worker);
 	nlohmann::json convertWorkerGC(const worker_gc_t* worker);
 	nlohmann::json convertMempool(const rte_mempool* mempool);
@@ -35,7 +32,4 @@ protected:
 
 protected:
 	cDataPlane* dataPlane;
-
-	std::thread thread;
-	int serverSocket;
 };


### PR DESCRIPTION
It's useless anyway.
Add a bit of clarification comments, also drop no longer used includes.

Resolves #115.