### PR TITLE
Non-contiguous DPDK port range

### DIFF
--- a/dataplane/base.h
+++ b/dataplane/base.h
@@ -64,6 +64,7 @@ public:
 		tQueueId inQueueId;
 	} workerPorts[CONFIG_YADECAP_WORKER_PORTS_SIZE];
 
+	tPortId ports[CONFIG_YADECAP_PORTS_SIZE];
 	unsigned int ports_count;
 	tQueueId outQueueId;
 

--- a/dataplane/controlplane.cpp
+++ b/dataplane/controlplane.cpp
@@ -102,8 +102,10 @@ void cControlPlane::start()
 	}
 
 	/// start devices
-	for (tPortId portId = 0; portId < rte_eth_dev_count_avail(); portId++)
+	for (const auto& portIter : dataPlane->ports)
 	{
+		const tPortId& portId = portIter.first;
+
 		int rc = rte_eth_dev_start(portId);
 		if (rc)
 		{
@@ -319,11 +321,9 @@ common::idp::getWorkerStats::response cControlPlane::getWorkerStats(const common
 			const auto& worker = dataPlane->workers.find(coreId)->second;
 
 			std::map<tPortId, common::worker::stats::port> portsStats;
-			for (tPortId portId = 0;
-			     portId < dataPlane->ports.size();
-			     portId++)
+			for (const auto& portIter : dataPlane->ports)
 			{
-				portsStats[portId] = worker->statsPorts[portId];
+				portsStats[portIter.first] = worker->statsPorts[portIter.first];
 			}
 
 			response[coreId] = {worker->iteration,
@@ -338,11 +338,9 @@ common::idp::getWorkerStats::response cControlPlane::getWorkerStats(const common
 		for (const auto& [coreId, worker] : dataPlane->workers)
 		{
 			std::map<tPortId, common::worker::stats::port> portsStats;
-			for (tPortId portId = 0;
-			     portId < dataPlane->ports.size();
-			     portId++)
+			for (const auto& portIter : dataPlane->ports)
 			{
-				portsStats[portId] = worker->statsPorts[portId];
+				portsStats[portIter.first] = worker->statsPorts[portIter.first];
 			}
 
 			response[coreId] = {worker->iteration,

--- a/dataplane/dataplane.h
+++ b/dataplane/dataplane.h
@@ -80,6 +80,7 @@ struct tDataPlaneConfig
 	*/
 	std::map<std::string, ///< interfaceName
 	         std::tuple<std::string, ///< pci
+	                    std::string, ///< name
 	                    bool, ///< symmetric_mode
 	                    uint64_t ///< rssFlags
 	                    >>

--- a/dataplane/globalbase.cpp
+++ b/dataplane/globalbase.cpp
@@ -623,7 +623,7 @@ eResult generation::updateLogicalPort(const common::idp::updateGlobalBase::updat
 		YADECAP_LOG_ERROR("invalid logicalPortId: '%u'\n", logicalPortId);
 		return eResult::invalidLogicalPortId;
 	}
-	if (portId >= dataPlane->ports.size())
+	if (!exist(dataPlane->ports, portId))
 	{
 		YADECAP_LOG_ERROR("invalid portId: '%u'\n", portId);
 		return eResult::invalidPortId;

--- a/dataplane/worker.cpp
+++ b/dataplane/worker.cpp
@@ -1091,10 +1091,11 @@ inline void cWorker::physicalPort_ingress_handle(const unsigned int& worker_port
 
 inline void cWorker::physicalPort_egress_handle()
 {
-	for (tPortId portId = 0;
-	     portId < basePermanently.ports_count;
-	     portId++)
+	for (uint32_t portId_i = 0;
+	     portId_i < basePermanently.ports_count;
+	     portId_i++)
 	{
+		const auto portId = basePermanently.ports[portId_i];
 		if (unlikely(physicalPort_stack[portId].mbufsCount == 0))
 		{
 			continue;


### PR DESCRIPTION
In some cases we do not need to use all ports provided by `DPDK`. Also the commit enables us to use port name instead of pci function address as there are some devices like Chelsio having more than one port sharing same pci function.

Closes #59