### PR TITLE
Dynamic allocation memory (final)

### DIFF
--- a/dataplane/dataplane.cpp
+++ b/dataplane/dataplane.cpp
@@ -1572,7 +1572,12 @@ eResult cDataPlane::parseConfig(const std::string& configFilePath)
 		}
 	}
 
-	config.memory = rootJson.value("memory", 0);
+	config.memory = std::to_string(rootJson.value("memory", 0));
+
+	if (rootJson.find("memory_numa") != rootJson.end())
+	{
+		config.memory = rootJson.find("memory_numa").value();
+	}
 
 	if (rootJson.find("sharedMemory") != rootJson.end())
 	{
@@ -1846,16 +1851,16 @@ eResult cDataPlane::initEal(const std::string& binaryPath,
 #endif
 	}
 
-	if (config.memory)
+	if (!config.memory.empty())
 	{
 		if (config.useHugeMem)
 		{
-			insert_eal_arg("--socket-mem=%u", config.memory);
-			insert_eal_arg("--socket-limit=%u", config.memory);
+			insert_eal_arg("--socket-mem=%s", config.memory.data());
+			insert_eal_arg("--socket-limit=%s", config.memory.data());
 		}
 		else
 		{
-			insert_eal_arg("-m %u", config.memory);
+			insert_eal_arg("-m %s", config.memory.data());
 		}
 	}
 

--- a/dataplane/dataplane.h
+++ b/dataplane/dataplane.h
@@ -52,7 +52,7 @@ struct tDataPlaneConfig
 	uint32_t SWNormalPriorityRateLimitPerWorker = 0;
 	uint32_t SWICMPOutRateLimit = 0;
 	uint32_t rateLimitDivisor = 1;
-	unsigned int memory = 0;
+	std::string memory;
 	std::map<std::string, std::tuple<unsigned int, unsigned int>> shared_memory;
 
 	std::vector<std::string> ealArgs;


### PR DESCRIPTION
dataplane: add config 'memory_numa' for pass to rte_init as `--socket-mem` and `--socket-limit` for limit memory on init

#58