### PR TITLE
Add dpdk and local ports mapping class

### DIFF
--- a/dataplane/dataplane.cpp
+++ b/dataplane/dataplane.cpp
@@ -721,10 +721,10 @@ eResult cDataPlane::initWorkers()
 		dataplane::base::permanently basePermanently;
 		basePermanently.globalBaseAtomic = globalBaseAtomics[socket_id];
 		basePermanently.outQueueId = outQueueId; ///< 0
-		basePermanently.ports_count = 0;
 		for (const auto& portIter : ports)
 		{
-			basePermanently.ports[basePermanently.ports_count++] = portIter.first;
+			if (!basePermanently.ports.Register(portIter.first))
+				return eResult::invalidPortsCount;
 		}
 
 		basePermanently.SWNormalPriorityRateLimitPerWorker = config.SWNormalPriorityRateLimitPerWorker;
@@ -803,14 +803,14 @@ eResult cDataPlane::initWorkers()
 			basePermanently.nat64stateful_numa_id = rte_cpu_to_be_16(socket_id);
 		}
 
-		basePermanently.ports_count = 0;
 		for (const auto& [port_id, port] : ports)
 		{
 			const auto& [interface_name, rx_queues, tx_queues_count, mac_address, pci, symmetric_mode] = port;
 			(void)mac_address;
 			(void)pci;
 
-			basePermanently.ports[basePermanently.ports_count++] = port_id;
+			if (!basePermanently.ports.Register(port_id))
+				return eResult::invalidPortsCount;
 
 			if (exist(rx_queues, coreId))
 			{

--- a/dataplane/worker.cpp
+++ b/dataplane/worker.cpp
@@ -1094,10 +1094,10 @@ inline void cWorker::physicalPort_ingress_handle(const unsigned int& worker_port
 inline void cWorker::physicalPort_egress_handle()
 {
 	for (uint32_t portId_i = 0;
-	     portId_i < basePermanently.ports_count;
+	     portId_i < basePermanently.ports.size();
 	     portId_i++)
 	{
-		const auto portId = basePermanently.ports[portId_i];
+		const auto portId = basePermanently.ports.ToDpdk(portId_i);
 		if (unlikely(physicalPort_stack[portId].mbufsCount == 0))
 		{
 			continue;

--- a/dataplane/worker.cpp
+++ b/dataplane/worker.cpp
@@ -1093,31 +1093,31 @@ inline void cWorker::physicalPort_ingress_handle(const unsigned int& worker_port
 
 inline void cWorker::physicalPort_egress_handle()
 {
-	for (uint32_t portId_i = 0;
-	     portId_i < basePermanently.ports.size();
-	     portId_i++)
+	for (uint32_t i = 0;
+	     i < basePermanently.ports.size();
+	     i++)
 	{
-		const auto portId = basePermanently.ports.ToDpdk(portId_i);
-		if (unlikely(physicalPort_stack[portId].mbufsCount == 0))
+		const auto portId = basePermanently.ports.ToDpdk(i);
+		if (unlikely(physicalPort_stack[i].mbufsCount == 0))
 		{
 			continue;
 		}
 
 		uint16_t txSize = rte_eth_tx_burst(portId,
 		                                   basePermanently.outQueueId,
-		                                   physicalPort_stack[portId].mbufs,
-		                                   physicalPort_stack[portId].mbufsCount);
+		                                   physicalPort_stack[i].mbufs,
+		                                   physicalPort_stack[i].mbufsCount);
 
-		statsPorts[portId].physicalPort_egress_drops += physicalPort_stack[portId].mbufsCount - txSize;
+		statsPorts[i].physicalPort_egress_drops += physicalPort_stack[i].mbufsCount - txSize;
 
 		for (;
-		     txSize < physicalPort_stack[portId].mbufsCount;
+		     txSize < physicalPort_stack[i].mbufsCount;
 		     txSize++)
 		{
-			rte_pktmbuf_free(physicalPort_stack[portId].mbufs[txSize]);
+			rte_pktmbuf_free(physicalPort_stack[i].mbufs[txSize]);
 		}
 
-		physicalPort_stack[portId].clear();
+		physicalPort_stack[i].clear();
 	}
 }
 
@@ -1358,6 +1358,7 @@ inline void cWorker::logicalPort_egress_handle()
 #endif
 		}
 
+		// check sanity, logicalPort.portId seems not constant
 		physicalPort_stack[logicalPort.portId].insert(mbuf);
 	}
 


### PR DESCRIPTION
Adds a fast way to convert logial port id, local to worker group, to global dpdk id and back.