### PR TITLE
Cleanup: Modernize deprecated C library headers

### DIFF
--- a/autotest/common.h
+++ b/autotest/common.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdio.h>
+#include <cstdio>
 
 #define ANSI_COLOR_RED "\x1b[31m"
 #define ANSI_COLOR_GREEN "\x1b[32m"

--- a/cli/latch.h
+++ b/cli/latch.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
 namespace latch
 {

--- a/controlplane/acl/dict.h
+++ b/controlplane/acl/dict.h
@@ -7,7 +7,7 @@
 #include "rule.h"
 
 #ifdef ACL_DEBUG
-#include <stdio.h>
+#include <cstdio>
 #define debug(format...) printf(format)
 #else
 #define debug(format...)

--- a/controlplane/acl_base.h
+++ b/controlplane/acl_base.h
@@ -4,7 +4,7 @@
 #include <set>
 #include <unordered_map>
 
-#include <inttypes.h>
+#include <cinttypes>
 
 using tAclGroupId = uint32_t;
 

--- a/controlplane/acl_tree.h
+++ b/controlplane/acl_tree.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <inttypes.h>
+#include <cinttypes>
 
 #include "common/acl.h"
 

--- a/dataplane/checksum.h
+++ b/dataplane/checksum.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <inttypes.h>
+#include <cinttypes>
 
 #include <rte_icmp.h>
 #include <rte_ip.h>

--- a/dataplane/common.h
+++ b/dataplane/common.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <arpa/inet.h>
-#include <stdio.h>
+#include <cstdio>
 
 #include <rte_ether.h>
 #include <rte_hash_crc.h>

--- a/dataplane/debug_latch.h
+++ b/dataplane/debug_latch.h
@@ -4,7 +4,7 @@
 
 #ifdef CONFIG_YADECAP_AUTOTEST
 
-#include <stdint.h>
+#include <cstdint>
 #include <unistd.h>
 
 #define LATCH_USLEEP_CYCLE 50

--- a/dataplane/dynamic_table.h
+++ b/dataplane/dynamic_table.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <inttypes.h>
+#include <cinttypes>
 
 #include "common/config.h"
 #include "common/define.h"

--- a/dataplane/flat.h
+++ b/dataplane/flat.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <inttypes.h>
+#include <cinttypes>
 
 #include <vector>
 

--- a/dataplane/fragmentation.h
+++ b/dataplane/fragmentation.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <inttypes.h>
+#include <cinttypes>
 
 #include <atomic>
 #include <map>

--- a/dataplane/hashtable.h
+++ b/dataplane/hashtable.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <cstdint>
 #include <memory.h>
-#include <stdint.h>
 
 #include <rte_byteorder.h>
 #include <rte_common.h>

--- a/dataplane/sock_dev.h
+++ b/dataplane/sock_dev.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #define SOCK_DEV_PREFIX "sock_dev:"
 

--- a/ext/murmurhash3.h
+++ b/ext/murmurhash3.h
@@ -16,7 +16,7 @@
 
 #define FORCE_INLINE	__forceinline
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #define ROTL32(x,y)	_rotl(x,y)
 #define ROTL64(x,y)	_rotl64(x,y)

--- a/ext/xxhash32.h
+++ b/ext/xxhash32.h
@@ -5,7 +5,7 @@
 //
 
 #pragma once
-#include <stdint.h> // for uint32_t and uint64_t
+#include <cstdint> // for uint32_t and uint64_t
 
 /// XXHash (32 bit), based on Yann Collet's descriptions, see http://cyan4973.github.io/xxHash/
 /** How to use:

--- a/librib/libyabird.h
+++ b/librib/libyabird.h
@@ -99,7 +99,7 @@ extern "C"
 //#define	YANET_DEBUG
 
 #ifdef YANET_DEBUG
-#include <stdio.h>
+#include <cstdio>
 
 extern int yanet_logfd;
 #define BP(fmt, ...)                                              \


### PR DESCRIPTION
Some headers from C library were deprecated in C++ and are no longer welcome in C++ codebases. For more details refer to the C++14 Standard [depr.c.headers] section.

This commit replaces C standard library headers with their C++ alternatives