### PR TITLE
Fix kernel interface stats

### DIFF
--- a/dataplane/controlplane.cpp
+++ b/dataplane/controlplane.cpp
@@ -1747,7 +1747,7 @@ void cControlPlane::mainThread()
 				}
 				auto to_drop = rxSize - txSize;
 				rte_pktmbuf_free_bulk(operational + txSize, to_drop);
-				sKniStats& stats = kernel_interfaces[i].stats;
+				sKniStats& stats = kernel_stats[i];
 				stats.odropped += to_drop;
 				stats.opackets += txSize;
 				stats.obytes += bytes;

--- a/dataplane/controlplane.h
+++ b/dataplane/controlplane.h
@@ -138,7 +138,6 @@ protected:
 	{
 		std::string interface_name;
 		tPortId kernel_port_id;
-		sKniStats stats;
 		rte_mbuf* mbufs[CONFIG_YADECAP_MBUFS_BURST_SIZE];
 		uint16_t mbufs_count = 0;
 	};

--- a/dataplane/report.cpp
+++ b/dataplane/report.cpp
@@ -364,7 +364,7 @@ nlohmann::json cReport::convertControlPlane(const cControlPlane* controlPlane)
 		nlohmann::json jsonKni;
 
 		const auto& port = controlPlane->kernel_interfaces[i];
-		const auto& stats = port.stats;
+		const auto& stats = controlPlane->kernel_stats[i];
 
 		jsonKni["portId"] = portmapper.ToDpdk(i);
 		jsonKni["interfaceName"] = port.interface_name;


### PR DESCRIPTION
Kni workload rewritten without maps breaks usage of sKniStats, a draft version of storing sKniStats inside KniPortData made its way into final version andis used in a couple of places. This commit fixes that