### PR TITLE
Remove unnecessary cast to char* in YADECAP_METADATA

### DIFF
--- a/dataplane/common.h
+++ b/dataplane/common.h
@@ -31,7 +31,7 @@
 #define YANET_MEMORY_BARRIER_COMPILE __asm__ __volatile__("" :: \
 	                                                          : "memory")
 
-#define YADECAP_METADATA(mbuf) ((dataplane::metadata*)((char*)(mbuf)->buf_addr))
+#define YADECAP_METADATA(mbuf) ((dataplane::metadata*)((mbuf)->buf_addr))
 
 #define YADECAP_ETHER_TYPE_MPLS (0x8847)
 #define YADECAP_MPLS_HEADER_SIZE 4


### PR DESCRIPTION
Apart from it being unnecessary, it could even result in some bad behavior, as GCC always assumes aligned pointer accesses and cast from `char *` to `dataplane::metadata *` increases required alignment from 1 to 4