### PR TITLE
Remove redundant memory_manager initialization

### DIFF
--- a/dataplane/dataplane.cpp
+++ b/dataplane/dataplane.cpp
@@ -46,7 +46,8 @@ cDataPlane::cDataPlane() :
         globalBaseSerial(0),
         report(this),
         controlPlane(new cControlPlane(this)),
-        bus(this)
+        bus(this),
+        memory_manager(this)
 {
 }
 
@@ -168,12 +169,6 @@ eResult cDataPlane::init(const std::string& binaryPath,
 	numaNodesInUse = worker_gcs.size();
 
 	result = initQueues();
-	if (result != eResult::success)
-	{
-		return result;
-	}
-
-	result = memory_manager.init(this);
 	if (result != eResult::success)
 	{
 		return result;

--- a/dataplane/dataplane.h
+++ b/dataplane/dataplane.h
@@ -22,6 +22,7 @@
 #include "config_values.h"
 #include "controlplane.h"
 #include "globalbase.h"
+#include "memory_manager.h"
 #include "neighbor.h"
 #include "report.h"
 #include "type.h"

--- a/dataplane/memory_manager.cpp
+++ b/dataplane/memory_manager.cpp
@@ -24,15 +24,9 @@ memory_pointer::~memory_pointer()
 	destructor(pointer);
 }
 
-memory_manager::memory_manager() :
-        dataplane(nullptr)
+memory_manager::memory_manager(cDataPlane* dplane) :
+        dataplane(dplane)
 {
-}
-
-eResult memory_manager::init(cDataPlane* dataplane)
-{
-	this->dataplane = dataplane;
-	return eResult::success;
 }
 
 inline std::string to_hex(const void* pointer)

--- a/dataplane/memory_manager.h
+++ b/dataplane/memory_manager.h
@@ -29,9 +29,8 @@ public:
 class memory_manager
 {
 public:
-	memory_manager();
+	memory_manager(cDataPlane*);
 
-	eResult init(cDataPlane* dataplane);
 	void report(nlohmann::json& json);
 	void limits(common::idp::limits::response& response);
 	eResult memory_manager_update(const common::idp::memory_manager_update::request& request);


### PR DESCRIPTION
For some reason trivial memory_manager initialization was done outside constructor. Always returning `eResult::success` initialization result was checked for really, truly, returning `eResult::success`.