### PR TITLE
Fixes UB when buffersize is zero

### DIFF
--- a/common/stream.h
+++ b/common/stream.h
@@ -304,7 +304,10 @@ inline void stream_in_t::pop(char* buffer, uint64_t bufferSize)
 		return;
 	}
 
-	memcpy(buffer, &this->inBuffer[inPosition], bufferSize);
+	if (bufferSize != 0)
+	{
+		memcpy(buffer, &this->inBuffer[inPosition], bufferSize);
+	}
 
 	inPosition += bufferSize;
 }


### PR DESCRIPTION
Passing invalid pointer to memcpy is UB even if bufferSize is zero