### PR TITLE
Fixes UB when buffersize is zero

### DIFF
--- a/common/acl.h
+++ b/common/acl.h
@@ -64,12 +64,12 @@ public:
 
 	inline void pop(common::stream_in_t& stream)
 	{
-		stream.pop((char*)values, sizeof(values));
+		stream.pop(values);
 	}
 
 	inline void push(common::stream_out_t& stream) const
 	{
-		stream.push((const char*)values, sizeof(values));
+		stream.push(values);
 	}
 
 	uint8_t is_multirefs;
@@ -94,16 +94,6 @@ struct transport_key_t
 		                second.group2,
 		                second.group3,
 		                second.network_flags);
-	}
-
-	void pop(stream_in_t& stream)
-	{
-		stream.pop((char*)this, sizeof(*this));
-	}
-
-	void push(stream_out_t& stream) const
-	{
-		stream.push((char*)this, sizeof(*this));
 	}
 
 	tAclGroupId network_id : 32;
@@ -168,16 +158,6 @@ struct total_key_t
 	{
 		return std::tie(acl_id, transport_id) <
 		       std::tie(second.acl_id, second.transport_id);
-	}
-
-	void pop(stream_in_t& stream)
-	{
-		stream.pop((char*)this, sizeof(*this));
-	}
-
-	void push(stream_out_t& stream) const
-	{
-		stream.push((char*)this, sizeof(*this));
 	}
 
 	tAclGroupId acl_id;

--- a/common/type.h
+++ b/common/type.h
@@ -100,16 +100,6 @@ public:
 		return *this;
 	}
 
-	void pop(stream_in_t& stream)
-	{
-		stream.pop(value);
-	}
-
-	void push(stream_out_t& stream) const
-	{
-		stream.push(value);
-	}
-
 public:
 	type_t value;
 };
@@ -2052,23 +2042,8 @@ struct common
 
 struct port
 {
-	port()
-	{
-		memset(this, 0, sizeof(*this));
-	}
-
-	void pop(stream_in_t& stream)
-	{
-		stream.pop((char*)this, sizeof(*this));
-	}
-
-	void push(stream_out_t& stream) const
-	{
-		stream.push((char*)this, sizeof(*this));
-	}
-
-	uint64_t physicalPort_egress_drops;
-	uint64_t controlPlane_drops; ///< @todo: DELETE
+	uint64_t physicalPort_egress_drops = 0;
+	uint64_t controlPlane_drops = 0; ///< @todo: DELETE
 };
 }
 }
@@ -2382,12 +2357,12 @@ public:
 
 	void pop(stream_in_t& stream)
 	{
-		stream.pop((char*)this, sizeof(*this));
+		stream.pop(reinterpret_cast<uint8_t(&)[sizeof(*this)]>(*this));
 	}
 
 	void push(stream_out_t& stream) const
 	{
-		stream.push((char*)this, sizeof(*this));
+		stream.push(reinterpret_cast<const uint8_t(&)[sizeof(*this)]>(*this));
 	}
 
 public:


### PR DESCRIPTION
Passing invalid pointer to memcpy is UB even if `bufferSize` is zero.