### PR TITLE
Build flag to create `librib` only

### DIFF
--- a/librib/meson.build
+++ b/librib/meson.build
@@ -11,3 +11,9 @@ libyabird = library('yanet-rib',
                     include_directories: yanet_rootdir,
                     dependencies: dependencies,
                     install: true)
+
+libyabird_static = static_library('yanet-rib',
+                                  sources,
+                                  include_directories: yanet_rootdir,
+                                  dependencies: dependencies,
+                                  install: true)

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,12 @@ add_global_arguments('-DGOOGLE_PROTOBUF_NO_RTTI', language: 'cpp')
 
 add_global_arguments('-Wno-unused-parameter', language: 'cpp')
 
+if target_option.contains('librib')
+    libjson = subproject('json')
+    subdir('librib')
+    subdir_done()
+endif
+
 libdpdk = subproject('dpdk', default_options: [
     'platform=generic',
     'cpu_instruction_set=corei7',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,6 @@
 option('target',
        type: 'combo',
-       choices : ['release', 'autotest', 'unittest', 'buildenv'],
+       choices : ['release', 'autotest', 'unittest', 'buildenv', 'librib'],
        value: 'release',
        description: 'Set the target build.')
 


### PR DESCRIPTION
The library may be used by other applications to inject routing information into YANET.