### PR TITLE
Ensure worker-local fw_state reflects cleared global firewall state

### DIFF
--- a/dataplane/worker_gc.cpp
+++ b/dataplane/worker_gc.cpp
@@ -621,6 +621,22 @@ void worker_gc_t::handle_acl_gc()
 
 			iter.unlock();
 		}
+		else
+		{
+			// The entry is invalid, likely due to a call to clearFWState().
+			iter.lock();
+			auto key = *iter.key();
+			iter.unlock();
+
+			common::idp::getFWState::key_t fw_key(
+			        std::uint8_t(key.proto),
+			        {rte_be_to_cpu_32(key.src_addr.address)},
+			        {rte_be_to_cpu_32(key.dst_addr.address)},
+			        key.src_port,
+			        key.dst_port);
+
+			fw_state_remove_stack.emplace_back(fw_key);
+		}
 	}
 
 	if (fw4_state_gc.offset == 0)
@@ -728,6 +744,22 @@ void worker_gc_t::handle_acl_gc()
 			}
 
 			iter.unlock();
+		}
+		else
+		{
+			// The entry is invalid, likely due to a call to clearFWState().
+			iter.lock();
+			auto key = *iter.key();
+			iter.unlock();
+
+			common::idp::getFWState::key_t fw_key(
+			        std::uint8_t(key.proto),
+			        {key.src_addr.bytes},
+			        {key.dst_addr.bytes},
+			        key.src_port,
+			        key.dst_port);
+
+			fw_state_remove_stack.emplace_back(fw_key);
 		}
 	}
 


### PR DESCRIPTION
The clearFWState() function clears global firewall state by invalidating all entries in the fw4_state and fw6_state hashtables via the clear() method. However, the worker-local fw_state, which caches firewall states for each worker, was not being updated to reflect these cleared entries. This led to inconsistencies where stale firewall state entries remained in the worker's fw_state cache, even though they had been cleared globally.

The issue arose because the handle_acl_gc() function only removed entries from fw_state based on timeout conditions. Entries that were invalidated by clearFWState() were skipped during garbage collection, as gc() only processes valid entries.

Updated handle_acl_gc() to explicitly check for invalidated entries (i.e., entries where the valid_mask has been cleared) during the gc() process. When such invalid entries are encountered, they are now added to fw_state_remove_stack, ensuring they are removed from the worker's fw_state cache.