### PR TITLE
Clean rib default in 075_counters_route test

### DIFF
--- a/autotest/units/001_one_port/075_counters_route/autotest.yaml
+++ b/autotest/units/001_one_port/075_counters_route/autotest.yaml
@@ -83,3 +83,7 @@ steps:
 
 - cli:
   - telegraf route
+
+# cleanup
+- cli: |
+    rib static remove default 0.0.0.0/0 200.0.2.1


### PR DESCRIPTION
Lack of cleanup resulted in failed CI tests, as the two tests ran consecutively, causing the 077_state_timeout test to fail: `./autotest/yanet-autotest-run.py --prefix=build_autotest autotest/units/001_one_port/ autotest/units/001_one_port/075_counters_route autotest/units/001_one_port/077_state_timeout`