### PR TITLE
Fix flapping of state timeout tests

### DIFF
--- a/autotest/units/001_one_port/077_state_timeout/autotest.yaml
+++ b/autotest/units/001_one_port/077_state_timeout/autotest.yaml
@@ -6,11 +6,7 @@ steps:
     send: 001-send.pcap
     expect: 001-expect.pcap
 
-- cli_check: |
-    fw list states
-    id        ruleno    label  rule
-    --------  --------  -----  --------------------------------------------------------------------------------------------
-    16777215  16777215         allow tcp from 10.0.0.1 80 to 10.0.0.2 12345 [own, last seen: 2s ago flags S:][packets: 0/0]
+- cli: fw list states | grep -q "allow tcp from 10.0.0.1 80 to 10.0.0.2 12345"
 
 - sleep: 6  # Wait for state to expire
 
@@ -26,20 +22,11 @@ steps:
     send: 001-send.pcap
     expect: 001-expect.pcap
 
-- cli_check: |
-    fw list states
-    id        ruleno    label  rule
-    --------  --------  -----  --------------------------------------------------------------------------------------------
-    16777215  16777215         allow tcp from 10.0.0.1 80 to 10.0.0.2 12345 [own, last seen: 2s ago flags S:][packets: 0/0]
+- cli: fw list states | grep -q "allow tcp from 10.0.0.1 80 to 10.0.0.2 12345"
 
 - sleep: 3  # Wait but state should still be present
 
-  # note that last seen value changes
-- cli_check: |
-    fw list states
-    id        ruleno    label  rule
-    --------  --------  -----  --------------------------------------------------------------------------------------------
-    16777215  16777215         allow tcp from 10.0.0.1 80 to 10.0.0.2 12345 [own, last seen: 5s ago flags S:][packets: 0/0]
+- cli: fw list states | grep -q "allow tcp from 10.0.0.1 80 to 10.0.0.2 12345"
 
 - sleep: 3  # Wait for state to expire
 

--- a/autotest/units/001_one_port/077_state_timeout_with_dump/autotest.yaml
+++ b/autotest/units/001_one_port/077_state_timeout_with_dump/autotest.yaml
@@ -10,19 +10,11 @@ steps:
   - ringTag: shm_2_0
     expect: 001-expect-dump-ring1.pcap
 
-- cli_check: |
-    fw list states
-    id        ruleno    label  rule
-    --------  --------  -----  -------------------------------------------------------------------------------------------
-    16777215  16777215         allow udp from 10.0.0.1 53 to 10.0.0.10 1024 [own, last seen: 2s ago flags :][packets: 0/0]
+- cli: fw list states | grep -q "allow udp from 10.0.0.1 53 to 10.0.0.10 1024"
 
 - sleep: 3  # Wait, state should still be present
 
-- cli_check: |
-    fw list states
-    id        ruleno    label  rule
-    --------  --------  -----  -------------------------------------------------------------------------------------------
-    16777215  16777215         allow udp from 10.0.0.1 53 to 10.0.0.10 1024 [own, last seen: 5s ago flags :][packets: 0/0]
+- cli: fw list states | grep -q "allow udp from 10.0.0.1 53 to 10.0.0.10 1024"
 
 - sleep: 3  # Wait for state to expire (total sleep 6s)
 
@@ -40,19 +32,11 @@ steps:
   - ringTag: shm_2_0
     expect: 002-expect-dump-ring1.pcap
 
-- cli_check: |
-    fw list states
-    id        ruleno    label  rule
-    --------  --------  -----  -------------------------------------------------------------------------------------------
-    16777215  16777215         allow udp from 10.0.0.1 53 to 10.0.0.10 1024 [own, last seen: 2s ago flags :][packets: 0/0]
+- cli: fw list states | grep -q "allow udp from 10.0.0.1 53 to 10.0.0.10 1024"
 
 - sleep: 3  # Wait, state should still be present
 
-- cli_check: |
-    fw list states
-    id        ruleno    label  rule
-    --------  --------  -----  -------------------------------------------------------------------------------------------
-    16777215  16777215         allow udp from 10.0.0.1 53 to 10.0.0.10 1024 [own, last seen: 5s ago flags :][packets: 0/0]
+- cli: fw list states | grep -q "allow udp from 10.0.0.1 53 to 10.0.0.10 1024"
 
 - sleep: 3  # Wait for state to expire (total sleep 6s)
 


### PR DESCRIPTION
Previous verisons were relying on the fact that `fw cli check` prints 2sec ago when seening states. But that depends on many factors, and sometimes it can be faster so we see 1sec ago, which results in "cli_check" step fail.

Now we just check whether the state is present with "grep -q"