### PR TITLE
YANET build images is ready to Ubuntu 24.04

### DIFF
--- a/build/Dockerfile.debian-package
+++ b/build/Dockerfile.debian-package
@@ -1,9 +1,9 @@
-ARG RELEASE=22.04
-FROM --platform=linux/amd64 ubuntu:${RELEASE}
+ARG BUILD_PLATFORM=linux/amd64
+ARG RELEASE=24.04
+FROM --platform=${BUILD_PLATFORM} ubuntu:${RELEASE} AS environment
 
-ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential \
     ninja-build \
     pkg-config \
@@ -27,7 +27,9 @@ RUN apt-get install -y --no-install-recommends \
     bison \
     debhelper-compat
 
-RUN python3 -m pip install meson==0.61.2
+# PEP 668 strict recommends to use virtualenv
+RUN python3 -m pip install meson==0.61.2 --break-system-packages \
+    || python3 -m pip install meson==0.61.2
 
 COPY . /opt/yanet
 WORKDIR /opt/yanet

--- a/build/Dockerfile.image
+++ b/build/Dockerfile.image
@@ -1,5 +1,6 @@
-ARG RELEASE=22.04
-FROM --platform=linux/amd64 ubuntu:${RELEASE} AS environment
+ARG BUILD_PLATFORM=linux/amd64
+ARG RELEASE=24.04
+FROM --platform=${BUILD_PLATFORM} ubuntu:${RELEASE} AS environment
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -26,7 +27,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bison \
         debhelper-compat
 
-RUN python3 -m pip install meson==0.61.2
+# PEP 668 strict recommends to use virtualenv
+RUN python3 -m pip install meson==0.61.2 --break-system-packages \
+        || python3 -m pip install meson==0.61.2
 
 
 FROM environment AS builder
@@ -52,7 +55,7 @@ RUN meson setup --prefix=/target \
 RUN meson compile -C build
 
 
-FROM --platform=linux/amd64 ubuntu:${RELEASE}
+FROM --platform=${BUILD_PLATFORM} ubuntu:${RELEASE}
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Support to build YANET for Ubuntu 24.04 with Python 3.12:
  break-system-packages should be used for global pip install.