### PR TITLE
Correct keep-state semantics

### DIFF
--- a/controlplane/unittest/parser.cpp
+++ b/controlplane/unittest/parser.cpp
@@ -750,7 +750,13 @@ TEST(Parser, 066_KeepState)
 	const auto rules = R"IPFW(
 add deny ip from any to any keep-state
 add deny ip from any to any keep-state
-:JUMP
+:JUMP1
+add deny ip from any to any keep-state
+add deny ip from any to any keep-state
+add deny ip from any to any keep-state
+:JUMP2
+add deny ip from any to any keep-state
+add deny ip from any to any keep-state
 add deny ip from any to any keep-state
 add deny ip from any to any keep-state
 )IPFW";
@@ -759,9 +765,11 @@ add deny ip from any to any keep-state
 	firewall.schedule_string(rules);
 	EXPECT_TRUE(firewall.parse());
 
-	unsigned int keep_state_rules = 4;
-	// Each keep-state adds an implicit check-state rule.
-	EXPECT_EQ(firewall.get_rules_size(), keep_state_rules * 2);
+	unsigned int keep_state_rules = 9;
+	unsigned int labels = 2;
+	// Each keep-state within a label block adds an implicit check-state rule
+	unsigned int implicit_check_state_rules = labels + 1;
+	EXPECT_EQ(firewall.get_rules_size(), keep_state_rules + implicit_check_state_rules);
 }
 
 } // namespace

--- a/controlplane/unittest/parser.cpp
+++ b/controlplane/unittest/parser.cpp
@@ -745,4 +745,23 @@ add skipto :BEGIN-section.service ip from any to any
 	EXPECT_TRUE(parse_rules(rules));
 }
 
+TEST(Parser, 066_KeepState)
+{
+	const auto rules = R"IPFW(
+add deny ip from any to any keep-state
+add deny ip from any to any keep-state
+:JUMP
+add deny ip from any to any keep-state
+add deny ip from any to any keep-state
+)IPFW";
+
+	ipfw::fw_config_t firewall;
+	firewall.schedule_string(rules);
+	EXPECT_TRUE(firewall.parse());
+
+	unsigned int keep_state_rules = 4;
+	// Each keep-state adds an implicit check-state rule.
+	EXPECT_EQ(firewall.get_rules_size(), keep_state_rules * 2);
+}
+
 } // namespace

--- a/libfwparser/fw_config.cpp
+++ b/libfwparser/fw_config.cpp
@@ -203,6 +203,8 @@ void fw_config_t::add_label(const std::string& s)
 	m_last_label = s;
 	m_labels.emplace(s, label_info_t{m_ruleno_last + 1, // we will jump to the next rule
 	                                 location_history_t{(unsigned int)l.begin.line, m_fileno.top()}});
+	// Since we can jump to this place, the next rule with keep-state should also perfrom state check
+	keep_state_with_implicit_check = true;
 }
 
 void fw_config_t::set_macro(const std::string& s)
@@ -826,7 +828,11 @@ void fw_config_t::add_rule_opcode(const rule_t::opcode_arg_t& value)
 			m_curr_rule->recordstate = true;
 			break;
 		case rule_t::opcode_t::KEEPSTATE:
-			m_curr_rule->implicit_check_state = true;
+			if (keep_state_with_implicit_check)
+			{
+				m_curr_rule->implicit_check_state = true;
+				keep_state_with_implicit_check = false;
+			}
 			m_curr_rule->recordstate = true;
 			break;
 		case rule_t::opcode_t::IPID:

--- a/libfwparser/fw_config.h
+++ b/libfwparser/fw_config.h
@@ -535,30 +535,30 @@ private:
 		TABLE,
 		RULE,
 	};
-	rule_ptr_t m_curr_rule;
-	rule_ptr_t m_prev_rule;
-	std::string m_last_label;
+	rule_ptr_t m_curr_rule{};
+	rule_ptr_t m_prev_rule{};
+	std::string m_last_label{};
 
-	entity_type m_curr_entity;
-	std::string m_curr_name;
-	tables::valtype_t m_curr_valtype;
-	uint32_t m_curr_value;
+	entity_type m_curr_entity{};
+	std::string m_curr_name{};
+	tables::valtype_t m_curr_valtype{};
+	uint32_t m_curr_value{};
 
 	// table entry context
-	tables::curr_entry_t m_curr_table_entry;
+	tables::curr_entry_t m_curr_table_entry{};
 
 	// addr/ports src or dst
-	bool m_curr_src;
-	rule_t::opcode_t m_curr_opcode;
-	rule_t::flags_options_t m_curr_options;
+	bool m_curr_src{};
+	rule_t::opcode_t m_curr_opcode{};
+	rule_t::flags_options_t m_curr_options{};
 
 	// recv/xmit/via
-	iface_direction_t m_curr_dir;
+	iface_direction_t m_curr_dir{};
 
 	// proto cache
-	std::map<std::string, uint8_t> m_protocols;
+	std::map<std::string, uint8_t> m_protocols{};
 	// services cache
-	std::map<std::string, uint16_t> m_services;
+	std::map<std::string, uint16_t> m_services{};
 
 	// internal methods
 	void check_table();
@@ -570,31 +570,31 @@ protected:
 	bool open(const std::string& file, bool nested = true);
 	bool close();
 
-	fw_lexer_t m_lexer;
-	int m_debug; // debug level
-	unsigned int m_ruleid_last;
-	unsigned int m_ruleno_last;
-	unsigned int m_ruleno_step;
-	std::vector<fw_config_history_t> m_history; // history of opened files
+	fw_lexer_t m_lexer{};
+	int m_debug{}; // debug level
+	unsigned int m_ruleid_last{};
+	unsigned int m_ruleno_last{};
+	unsigned int m_ruleno_step{};
+	std::vector<fw_config_history_t> m_history{}; // history of opened files
 	// lexer cursor location, current filename and its number in m_history
-	std::stack<location> m_location;
-	std::stack<istream_ptr_t> m_filestrm;
-	std::stack<unsigned int> m_fileno;
+	std::stack<location> m_location{};
+	std::stack<istream_ptr_t> m_filestrm{};
+	std::stack<unsigned int> m_fileno{};
 
-	std::map<std::string, dns_addresses_t> m_dns_cache;
-	std::map<std::string, label_info_t> m_labels;
+	std::map<std::string, dns_addresses_t> m_dns_cache{};
+	std::map<std::string, label_info_t> m_labels{};
 
 	// keep track of used skipto labels
 	std::map<std::string,
 	         std::vector<rule_ptr_t>>
-	        m_skipto_labels;
+	        m_skipto_labels{};
 
-	std::map<std::string, macro_t> m_macros;
-	std::map<std::string, table_t> m_tables;
+	std::map<std::string, macro_t> m_macros{};
+	std::map<std::string, table_t> m_tables{};
 	// ruleno -> vector<rule_t *>
 	std::map<unsigned int, // rulenum
 	         std::vector<rule_ptr_t>>
-	        m_rules;
+	        m_rules{};
 };
 
 } // namespace ipfw

--- a/libfwparser/fw_config.h
+++ b/libfwparser/fw_config.h
@@ -524,6 +524,11 @@ public:
 		return m_labels;
 	}
 
+	[[nodiscard]] unsigned int get_rules_size() const
+	{
+		return m_ruleid_last;
+	}
+
 private:
 	void setup_lexer(const std::string& name, istream_ptr_t isrm, bool nested);
 	// parser's context

--- a/libfwparser/fw_config.h
+++ b/libfwparser/fw_config.h
@@ -549,6 +549,12 @@ private:
 	tables::valtype_t m_curr_valtype{};
 	uint32_t m_curr_value{};
 
+	// Flag to keep track whether a keep-state rule should imply
+	// implicit state check. Resets when we meet a label.
+	// By default it's true since we're not necesserily will have a
+	// label at the beggining of the ruleset
+	bool keep_state_with_implicit_check = true;
+
 	// table entry context
 	tables::curr_entry_t m_curr_table_entry{};
 


### PR DESCRIPTION
According to the [IPFW syntax](https://man.freebsd.org/cgi/man.cgi?ipfw(8)), which YANET's syntax is based on:

> Please note that keep-state and limit imply an implicit check-state for all packets (not only those matched by the rule), but record-state and set-limit have no implicit check-state.


Currently (in the `main` branch), this leads to each keep-state rule being transformed into two rules during ruleset processing: a check-state rule for all packets and the original rule with record-state.

As a result, the total number of rules in the ruleset nearly doubles, significantly slowing down compilation.

Now, if multiple keep-state rules are in a row, we add a check-state before the first one and skip it for the rest. Reset this behavior when a label is encountered, as labels can be targets of `skipto`.

For example, a ruleset like this:

```
allow R1 keep-state
allow R2 keep-state
allow R3 keep-state
:SMTH
allow R4 keep-state
allow R5 keep-state
allow R6 keep-state
```
Would now become:

```
check-state A
allow R1 record-state
allow R2 record-state
allow R3 record-state
:SMTH
check-state A
allow R4 record-state
allow R5 record-state
allow R6 record-state
```
Instead of the previous behavior:

```
check-state A
allow R1 record-state
check-state A
allow R2 record-state
check-state A
allow R3 record-state
:SMTH
check-state A
allow R4 record-state
check-state A
allow R5 record-state
check-state A
allow R6 record-state
```