### PR TITLE
Remove Ubuntu 18.04 build from CI

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -72,21 +72,6 @@ jobs:
           meson compile -C build
       - run: meson install -C build
 
-  build-ubuntu1804:
-    name: build (Ubuntu 18.04)
-    needs: formatting-check
-    runs-on: ubuntu-24.04
-    container:
-      image: yanetplatform/builder_ubuntu18.04-lite
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          submodules: recursive
-      - run: |
-          meson setup --prefix=/target -Dstrip=true build
-          meson compile -C build
-      - run: meson install -C build
-
   unittest:
     needs: build-unittest
     runs-on: ubuntu-24.04

--- a/docs/build.md
+++ b/docs/build.md
@@ -4,7 +4,7 @@ Hardware:
 - Memory: 64G
 
 Software:
-- OS: Ubuntu 18.04
+- OS: Ubuntu 22.04
 - git
 - gcc or clang
 - DPDK v22.11.2


### PR DESCRIPTION
We no longer support this version.
Now the minimal supported version is Ubuntu 22.04