### PR TITLE
Refactor initEal function

### DIFF
--- a/common/utils.h
+++ b/common/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <bitset>
 #include <iomanip>
 #include <vector>
 
@@ -45,6 +46,33 @@ inline std::vector<std::string> split(const std::string& str, char delimiter)
 {
 	return split(std::string_view(str), delimiter);
 }
+
+// Converts a std::bitset to a hexadecimal string representation.
+template<size_t N>
+std::string bitset_to_hex_string(const std::bitset<N>& bs)
+{
+	static_assert(N % 4 == 0, "Bitset size must be a multiple of 4 for hex conversion.");
+
+	std::stringstream ss;
+	ss << "0x";
+
+	// We iterate from the most significant nibble (group of 4 bits) to the least.
+	for (int i = N - 4; i >= 0; i -= 4)
+	{
+		unsigned int nibble = 0;
+		// Convert 4 bits to an integer value (0-15)
+		for (int j = 0; j < 4; ++j)
+		{
+			if (bs.test(i + j))
+			{
+				nibble |= (1 << j);
+			}
+		}
+		ss << std::hex << nibble;
+	}
+	return ss.str();
+}
+
 
 }
 // namespace utils


### PR DESCRIPTION
Made buffer manage memory automatically. The fixed-size char buffer[8192] and manual position tracking is error prone.

Remove insert_eal_arg macro as it obscures logic and lacks type safety. Now we just store arguments in a vector and convert it to C-style array in the end.

std::bitset<64> and its to_ullong() method are remade to allow the use of more than 64 cores.