### PR TITLE
Refactor initEal function

### DIFF
--- a/common/utils.h
+++ b/common/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <bitset>
 #include <iomanip>
 #include <vector>
 
@@ -44,6 +45,32 @@ template<typename T, typename = std::enable_if_t<!std::is_same_v<T, const char*>
 inline std::vector<std::string> split(const std::string& str, char delimiter)
 {
 	return split(std::string_view(str), delimiter);
+}
+
+// Converts a std::bitset to a hexadecimal string representation.
+template<size_t N>
+std::string bitset_to_hex_string(const std::bitset<N>& bs)
+{
+	static_assert(N % 4 == 0, "Bitset size must be a multiple of 4 for hex conversion.");
+
+	std::stringstream ss;
+	ss << "0x";
+
+	// We iterate from the most significant nibble (group of 4 bits) to the least.
+	for (int i = N - 4; i >= 0; i -= 4)
+	{
+		unsigned int nibble = 0;
+		// Convert 4 bits to an integer value (0-15)
+		for (int j = 0; j < 4; ++j)
+		{
+			if (bs.test(i + j))
+			{
+				nibble |= (1 << j);
+			}
+		}
+		ss << std::hex << nibble;
+	}
+	return ss.str();
 }
 
 }

--- a/dataplane/dataplane.cpp
+++ b/dataplane/dataplane.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <arpa/inet.h>
 #include <bitset>
 #include <cstdint>
@@ -34,6 +35,7 @@
 #include "common/idp.h"
 #include "common/result.h"
 #include "common/tsc_deltas.h"
+#include "common/utils.h"
 #include "dataplane.h"
 #include "dataplane/sdpserver.h"
 #include "globalbase.h"
@@ -2343,68 +2345,55 @@ eResult cDataPlane::checkConfig()
 eResult cDataPlane::initEal(const std::string& binaryPath,
                             const std::string& filePrefix)
 {
-#define insert_eal_arg(args...)                                                                               \
-	do                                                                                                    \
-	{                                                                                                     \
-		eal_argv[eal_argc++] = &buffer[bufferPosition];                                               \
-		bufferPosition += snprintf(&buffer[bufferPosition], sizeof(buffer) - bufferPosition, ##args); \
-		bufferPosition++;                                                                             \
-	} while (0)
+	std::vector<std::string> args;
 
-	unsigned int bufferPosition = 0;
-	char buffer[8192];
+	args.push_back(binaryPath);
 
-	unsigned int eal_argc = 0;
-	char* eal_argv[128];
+	// Add all generic EAL arguments from the configuration
+	args.insert(args.end(), config.ealArgs.begin(), config.ealArgs.end());
 
-	insert_eal_arg("%s", binaryPath.data());
+	// Construct the core mask argument for up to 128 cores
+	// We use a 128-bit bitset and a helper to convert it to a hex string.
+	constexpr size_t MAX_CORES = 128;
+	std::bitset<MAX_CORES> cores_mask;
 
-	for (auto& arg : config.ealArgs)
-	{
-		insert_eal_arg("%s", arg.c_str());
-	}
-
-	insert_eal_arg("-c");
-
-	std::bitset<std::numeric_limits<uint_least64_t>::digits> cores_mask;
 	cores_mask[config.controlPlaneCoreId] = true;
-	for (const auto& iter : config.controlplane_workers)
+	for (const auto& [coreId, workerConfig] : config.controlplane_workers)
 	{
-		const tCoreId& coreId = iter.first;
 		cores_mask[coreId] = true;
 	}
 	for (const auto& coreId : config.workerGCs)
 	{
 		cores_mask[coreId] = true;
 	}
-	for (const auto& iter : config.workers)
+	for (const auto& [coreId, workerConfig] : config.workers)
 	{
-		const tCoreId& coreId = iter.first;
 		cores_mask[coreId] = true;
 	}
-	insert_eal_arg("0x%" PRIx64, static_cast<uint_least64_t>(cores_mask.to_ullong()));
+
+	args.emplace_back("-c");
+	// This is necessary because std::bitset::to_string() produces a binary string,
+	// and to_ullong() is limited to 64 bits. DPDK's -c coremask expects hex.
+	args.push_back(utils::bitset_to_hex_string(cores_mask));
 
 #if RTE_VERSION >= RTE_VERSION_NUM(20, 11, 0, 0)
-	insert_eal_arg("--main-lcore");
-	insert_eal_arg("%u", config.controlPlaneCoreId);
+	args.emplace_back("--main-lcore");
 #else
-	insert_eal_arg("--master-lcore");
-	insert_eal_arg("%u", config.controlPlaneCoreId);
+	args.emplace_back("--master-lcore");
 #endif
+	args.push_back(std::to_string(config.controlPlaneCoreId));
 
 	if (!config.useHugeMem)
 	{
-		insert_eal_arg("--no-huge");
+		args.emplace_back("--no-huge");
 	}
 
-	insert_eal_arg("--proc-type=primary");
+	args.emplace_back("--proc-type=primary");
 
-	for (const auto& port : config.ports)
+	// Device whitelist
+	for (const auto& [portId, portConfig] : config.ports)
 	{
-		const auto& [pci, name, symmetric_mode, rss_flags] = port.second;
-		GCC_BUG_UNUSED(name);
-		GCC_BUG_UNUSED(symmetric_mode);
-		GCC_BUG_UNUSED(rss_flags);
+		const auto& [pci, name, symmetric_mode, rss_flags] = portConfig;
 
 		// Do not whitelist sock dev virtual devices
 		if (StartsWith(name, SOCK_DEV_PREFIX))
@@ -2413,41 +2402,53 @@ eResult cDataPlane::initEal(const std::string& binaryPath,
 		}
 
 #if RTE_VERSION >= RTE_VERSION_NUM(20, 11, 0, 0)
-		insert_eal_arg("-a");
-		insert_eal_arg("%s", pci.data());
+		args.emplace_back("-a");
 #else
-		insert_eal_arg("--pci-whitelist=%s", pci.data());
+		args.emplace_back("--pci-whitelist");
 #endif
+		args.push_back(pci);
 	}
 
+	// Memory allocation configuration
 	if (!config.memory.empty())
 	{
 		if (config.useHugeMem)
 		{
-			insert_eal_arg("--socket-mem=%s", config.memory.data());
-			insert_eal_arg("--socket-limit=%s", config.memory.data());
+			args.emplace_back("--socket-mem");
+			args.push_back(config.memory);
+			args.emplace_back("--socket-limit");
+			args.push_back(config.memory);
 		}
 		else
 		{
-			insert_eal_arg("-m %s", config.memory.data());
+			args.emplace_back("-m");
+			args.push_back(config.memory);
 		}
 	}
 
-	if (filePrefix.size())
+	if (!filePrefix.empty())
 	{
-		insert_eal_arg("--file-prefix=%s", filePrefix.data());
+		args.emplace_back("--file-prefix");
+		args.push_back(filePrefix);
 	}
 
-	eal_argv[eal_argc] = nullptr;
+	// Prepare for rte_eal_init
+	// Convert the vector of std::string to the required C-style char* array.
+	// The strings in `args` will outlive the pointers in `eal_argv`, ensuring validity.
+	std::vector<char*> eal_argv;
+	eal_argv.reserve(args.size() + 1); // +1 for the terminating nullptr
+	for (auto& arg : args)
+	{
+		eal_argv.push_back(arg.data());
+	}
+	eal_argv.push_back(nullptr);
 
-	int ret = rte_eal_init(eal_argc, eal_argv);
+	int ret = rte_eal_init(eal_argv.size() - 1, eal_argv.data());
 	if (ret < 0)
 	{
-		YADECAP_LOG_ERROR("rte_eal_init() = %d\n", ret);
+		YADECAP_LOG_ERROR("rte_eal_init() failed with error %d: %s\n", ret, rte_strerror(rte_errno));
 		return eResult::errorInitEal;
 	}
 
 	return eResult::success;
-
-#undef insert_eal_arg
 }


### PR DESCRIPTION
Made buffer manage memory automatically. The fixed-size char buffer[8192] and manual position tracking is error prone.

Remove insert_eal_arg macro as it obscures logic and lacks type safety. Now we just store arguments in a vector and convert it to C-style array in the end.

std::bitset<64> and its to_ullong() method are remade to allow the use of more than 64 cores.