### PR TITLE
Fix accidental iterator overload for string literals

### DIFF
--- a/cli/develop.h
+++ b/cli/develop.h
@@ -149,7 +149,7 @@ inline void counter(uint32_t counter_id, const std::optional<uint32_t>& range_si
 	const auto& response = common::sdp::SdpClient::GetCounters(counter_ids);
 
 	TablePrinter table;
-	table.insert("counter_id", "value");
+	table.insert_row("counter_id", "value");
 
 	for (uint32_t i = 0; i < counter_ids.size(); i++)
 	{

--- a/cli/dregress.h
+++ b/cli/dregress.h
@@ -43,8 +43,8 @@ void announce()
 	const auto response = controlPlane.dregress_config();
 
 	TablePrinter table;
-	table.insert("module",
-	             "announces");
+	table.insert_row("module",
+	                 "announces");
 
 	for (const auto& [module_name, dregress] : response)
 	{

--- a/cli/table_printer.h
+++ b/cli/table_printer.h
@@ -45,8 +45,15 @@ public:
 		insert_row(std::move(row));
 	}
 
-	// Insert values from a container as one row
-	template<typename Iterator, typename = typename std::iterator_traits<Iterator>::iterator_category>
+	/*
+	 * Insert values from a container as one row
+	 *
+	 * Disable this function if the iterator's value_type is a char, otherwise
+	 * it will win overload on things like insert_row("a", "b");
+	 */
+	template<typename Iterator,
+	         typename = typename std::iterator_traits<Iterator>::iterator_category,
+	         std::enable_if_t<!std::is_same_v<std::remove_cv_t<typename std::iterator_traits<Iterator>::value_type>, char>, int> = 0>
 	void insert_row(Iterator begin, Iterator end)
 	{
 		std::vector<std::string> row;
@@ -62,8 +69,13 @@ public:
 	 *
 	 * Useful when we have a container of containers like the "responce"
 	 * object obtained from controlplane
+	 *
+	 * Disable this function if the iterator's value_type is a char, otherwise
+	 * it will win overload on things like insert("a", "b");
 	 */
-	template<typename Iterator, typename = typename std::iterator_traits<Iterator>::iterator_category>
+	template<typename Iterator,
+	         typename = typename std::iterator_traits<Iterator>::iterator_category,
+	         std::enable_if_t<!std::is_same_v<std::remove_cv_t<typename std::iterator_traits<Iterator>::value_type>, char>, int> = 0>
 	void insert(Iterator begin, Iterator end)
 	{
 		for (auto it = begin; it != end; ++it)


### PR DESCRIPTION
Previously, calls like table.insert("a", "b") would invoke the iterator overload accepting (begin, end), leading to misinterpretation of C-style strings as containers. The correct intent was to insert a row, not iterate.

Replace mistaken uses of .insert("...") with the correct .insert_row("...") Disable insert/insert_row if the value_type is char.