### PR TITLE
Fix poor design decisions in TablePrinter, split iterator and args overloads

### DIFF
--- a/cli/develop.h
+++ b/cli/develop.h
@@ -363,7 +363,7 @@ private:
 
 		utils::zip_apply(op, of_store_tuple, cnt_tuple);
 
-		table.insert_row(row.begin(), row.end());
+		table.insert_row_from_range(row.begin(), row.end());
 	}
 };
 

--- a/cli/helper.h
+++ b/cli/helper.h
@@ -108,7 +108,7 @@ inline void FillAndPrintTable(const std::initializer_list<std::string_view>& hea
 {
 	TablePrinter table(config);
 
-	table.insert_row(headers.begin(), headers.end());
-	table.insert(data.begin(), data.end());
+	table.insert_row_from_range(headers.begin(), headers.end());
+	table.insert_from_range(data.begin(), data.end());
 	table.Print();
 }

--- a/cli/table_printer.h
+++ b/cli/table_printer.h
@@ -45,16 +45,9 @@ public:
 		insert_row(std::move(row));
 	}
 
-	/*
-	 * Insert values from a container as one row
-	 *
-	 * Disable this function if the iterator's value_type is a char, otherwise
-	 * it will win overload on things like insert_row("a", "b");
-	 */
-	template<typename Iterator,
-	         typename = typename std::iterator_traits<Iterator>::iterator_category,
-	         std::enable_if_t<!std::is_same_v<std::remove_cv_t<typename std::iterator_traits<Iterator>::value_type>, char>, int> = 0>
-	void insert_row(Iterator begin, Iterator end)
+	// Insert values from a container as one row
+	template<typename Iterator, typename = typename std::iterator_traits<Iterator>::iterator_category>
+	void insert_row_from_range(Iterator begin, Iterator end)
 	{
 		std::vector<std::string> row;
 		for (auto it = begin; it != end; ++it)
@@ -69,14 +62,9 @@ public:
 	 *
 	 * Useful when we have a container of containers like the "responce"
 	 * object obtained from controlplane
-	 *
-	 * Disable this function if the iterator's value_type is a char, otherwise
-	 * it will win overload on things like insert("a", "b");
 	 */
-	template<typename Iterator,
-	         typename = typename std::iterator_traits<Iterator>::iterator_category,
-	         std::enable_if_t<!std::is_same_v<std::remove_cv_t<typename std::iterator_traits<Iterator>::value_type>, char>, int> = 0>
-	void insert(Iterator begin, Iterator end)
+	template<typename Iterator, typename = typename std::iterator_traits<Iterator>::iterator_category>
+	void insert_from_range(Iterator begin, Iterator end)
 	{
 		for (auto it = begin; it != end; ++it)
 		{


### PR DESCRIPTION
Overloading with both (args...) and (Iterator, Iterator) led to confusion and bugs.

Drop tricks, use explicit insert_row_from_range/insert_from_range methods for containers.