### PR TITLE
Change the output of debugging messages when working with shared memory

### DIFF
--- a/common/sdpclient.h
+++ b/common/sdpclient.h
@@ -361,7 +361,7 @@ private:
 			sdp_data.metadata_worker.size = ReadValue(buffer, index + 5);
 			// 6 - n1 = size MetadataWorker.counter_positions
 			uint64_t n1 = ReadValue(buffer, index + 6);
-			// 7-9 - значения из MetadataWorker
+			// 7-9 - values from MetadataWorker
 			sdp_data.metadata_worker_gc.start_counters = ReadValue(buffer, index + 7);
 			sdp_data.metadata_worker_gc.start_stats = ReadValue(buffer, index + 8);
 			sdp_data.metadata_worker_gc.size = ReadValue(buffer, index + 9);

--- a/common/sdpcommon.h
+++ b/common/sdpcommon.h
@@ -189,7 +189,7 @@ struct DataPlaneInSharedMemory
 		{
 			if (munmap(dataplane_data, size) < 0)
 			{
-				YANET_LOG_ERROR("Error munmap %d: %s", errno, strerror(errno));
+				YANET_LOG_DEBUG("Error munmap %d: %s\n", errno, strerror(errno));
 			}
 			dataplane_data = nullptr;
 		}

--- a/common/shared_memory.h
+++ b/common/shared_memory.h
@@ -120,6 +120,11 @@ public:
 			YANET_LOG_ERROR("filename=%s, mmap(%p, %lu, %d, %d, %d, 0)\n", filename.c_str(), nullptr, size, prot, flags_mmap, fd);
 			return nullptr;
 		}
+		YANET_LOG_INFO("mmap allocated=%p, socket=%s, size=%ld, filename=%s\n",
+		               addr,
+		               (socket_id.has_value() ? std::to_string(*socket_id).c_str() : "any"),
+		               size,
+		               filename.c_str());
 
 		// Zero memory
 		memset(addr, 0, size);
@@ -176,6 +181,11 @@ public:
 			YANET_LOG_ERROR("shmat(%d, %p, %d): %s\n", shmid, nullptr, 0, strerror(errno));
 			return nullptr;
 		}
+		YANET_LOG_INFO("shmat allocated=%p, socket=%s, size=%ld, key=%d\n",
+		               addr,
+		               (socket_id.has_value() ? std::to_string(*socket_id).c_str() : "any"),
+		               size,
+		               key);
 
 		// Zero memory
 		memset(addr, 0, size);
@@ -297,7 +307,7 @@ private:
 				numa_set_preferred(*socket_id);
 				if (errno != 0)
 				{
-					YANET_LOG_ERROR("numa_set_preferred(%d): %s\n", *socket_id, strerror(errno));
+					YANET_LOG_DEBUG("numa_set_preferred(%d): %s\n", *socket_id, strerror(errno));
 				}
 			}
 		}

--- a/dataplane/sdpserver.h
+++ b/dataplane/sdpserver.h
@@ -49,7 +49,7 @@ public:
 			void* buffer = common::ipc::SharedMemory::CreateBufferFile(filename, size, use_huge_tlb, socket_id);
 			if (buffer == nullptr)
 			{
-				YANET_LOG_ERROR("Error create buffer in shared memory for workers on numa=%d, filename=%s, size=%ld",
+				YANET_LOG_ERROR("Error create buffer in shared memory for workers on numa=%d, filename=%s, size=%ld\n",
 				                socket_id,
 				                filename.c_str(),
 				                size);
@@ -60,7 +60,7 @@ public:
 			void* buffer = common::ipc::SharedMemory::CreateBufferKey(key_shared_memory_segment, size, use_huge_tlb, socket_id);
 			if (buffer == nullptr)
 			{
-				YANET_LOG_ERROR("Error create buffer in shared memory for workers on numa=%d, key=%d, size=%ld",
+				YANET_LOG_ERROR("Error create buffer in shared memory for workers on numa=%d, key=%d, size=%ld\n",
 				                socket_id,
 				                key_shared_memory_segment,
 				                size);
@@ -92,7 +92,7 @@ public:
 		                                                                      std::nullopt);
 		if (sdp_data.dataplane_data == nullptr)
 		{
-			YANET_LOG_ERROR("Error create buffer in shared memory for dataplane data, filename=%s, size=%ld",
+			YANET_LOG_ERROR("Error create buffer in shared memory for dataplane data, filename=%s, size=%ld\n",
 			                YANET_SHARED_MEMORY_FILE_DATAPLANE,
 			                sdp_data.size_dataplane_buffer);
 			return eResult::errorInitSharedMemory;
@@ -104,7 +104,7 @@ public:
 		                                                                     std::nullopt);
 		if (sdp_data.dataplane_data == nullptr)
 		{
-			YANET_LOG_ERROR("Error create buffer in shared memory for dataplane data, key=%d, size=%ld",
+			YANET_LOG_ERROR("Error create buffer in shared memory for dataplane data, key=%d, size=%ld\n",
 			                key_shared_memory_segment,
 			                sdp_data.size_dataplane_buffer);
 			return eResult::errorInitSharedMemory;
@@ -175,7 +175,7 @@ private:
 			WriteValue(sdp_data, index + 5, sdp_data.metadata_worker.size);
 			// 6 - n1 = size MetadataWorker.counter_positions
 			WriteValue(sdp_data, index + 6, sdp_data.metadata_worker.counter_positions.size());
-			// 7-9 - значения из MetadataWorker
+			// 7-9 - values from MetadataWorker
 			WriteValue(sdp_data, index + 7, sdp_data.metadata_worker_gc.start_counters);
 			WriteValue(sdp_data, index + 8, sdp_data.metadata_worker_gc.start_stats);
 			WriteValue(sdp_data, index + 9, sdp_data.metadata_worker_gc.size);


### PR DESCRIPTION
Some messages may break the collection of counters.