### PR TITLE
Fix a bug that caused crashes when all workers were placed on a single NUMA node

### DIFF
--- a/dataplane/base.h
+++ b/dataplane/base.h
@@ -97,6 +97,9 @@ public:
 	/// Used to distribute firewall states.
 	dataplane::globalBase::atomic* globalBaseAtomics[YANET_CONFIG_NUMA_SIZE];
 
+	/// Actual number of active NUMA nodes
+	uint32_t activeNumaNodesCount{};
+
 	unsigned int workerPortsCount;
 	struct
 	{

--- a/dataplane/worker.cpp
+++ b/dataplane/worker.cpp
@@ -3179,7 +3179,7 @@ inline void cWorker::nat64stateful_lan_handle()
 
 				/// @todo: create cross-numa state over slowworker?
 				for (unsigned int numa_i = 0;
-				     numa_i < YANET_CONFIG_NUMA_SIZE;
+				     numa_i < basePermanently.activeNumaNodesCount;
 				     numa_i++)
 				{
 					auto* globalbase_atomic = basePermanently.globalBaseAtomics[numa_i];
@@ -3219,7 +3219,7 @@ inline void cWorker::nat64stateful_lan_handle()
 				/// @todo: create cross-numa state over slowworker?
 				value.timestamp_last_packet = basePermanently.globalBaseAtomic->currentTime - YANET_CONFIG_STATE_TIMEOUT_MAX;
 				for (unsigned int numa_i = 0;
-				     numa_i < YANET_CONFIG_NUMA_SIZE;
+				     numa_i < basePermanently.activeNumaNodesCount;
 				     numa_i++)
 				{
 					auto* globalbase_atomic = basePermanently.globalBaseAtomics[numa_i];
@@ -4999,7 +4999,7 @@ inline void cWorker::acl_create_keepstate(rte_mbuf* mbuf, tAclId aclId, const co
 		value.tcp.dst_flags = 0;
 
 		bool emit = false;
-		for (unsigned int idx = 0; idx < YANET_CONFIG_NUMA_SIZE; ++idx)
+		for (unsigned int idx = 0; idx < basePermanently.activeNumaNodesCount; ++idx)
 		{
 			dataplane::globalBase::atomic* atomic = basePermanently.globalBaseAtomics[idx];
 			if (atomic == nullptr)
@@ -5096,7 +5096,7 @@ inline void cWorker::acl_create_keepstate(rte_mbuf* mbuf, tAclId aclId, const co
 		value.tcp.dst_flags = 0;
 
 		bool emit = false;
-		for (unsigned int idx = 0; idx < YANET_CONFIG_NUMA_SIZE; ++idx)
+		for (unsigned int idx = 0; idx < basePermanently.activeNumaNodesCount; ++idx)
 		{
 			dataplane::globalBase::atomic* atomic = basePermanently.globalBaseAtomics[idx];
 			if (atomic == nullptr)

--- a/dataplane/worker_gc.cpp
+++ b/dataplane/worker_gc.cpp
@@ -235,7 +235,7 @@ void worker_gc_t::handle_nat64stateful_gc()
 
 		/// check other wan tables
 		for (unsigned int numa_i = 0;
-		     numa_i < YANET_CONFIG_NUMA_SIZE;
+		     numa_i < base_permanently.activeNumaNodesCount;
 		     numa_i++)
 		{
 			auto* globalbase_atomic = base_permanently.globalBaseAtomics[numa_i];
@@ -271,7 +271,7 @@ void worker_gc_t::handle_nat64stateful_gc()
 
 		/// check lan tables
 		for (unsigned int numa_i = 0;
-		     numa_i < YANET_CONFIG_NUMA_SIZE;
+		     numa_i < base_permanently.activeNumaNodesCount;
 		     numa_i++)
 		{
 			auto* globalbase_atomic = base_permanently.globalBaseAtomics[numa_i];
@@ -420,7 +420,7 @@ void worker_gc_t::handle_balancer_gc()
 				iter.unlock();
 
 				for (unsigned int numa_i = 0;
-				     numa_i < YANET_CONFIG_NUMA_SIZE;
+				     numa_i < base_permanently.activeNumaNodesCount;
 				     numa_i++)
 				{
 					dataplane::globalBase::atomic* globalbase_atomic_other = base_permanently.globalBaseAtomics[numa_i];
@@ -949,7 +949,7 @@ void worker_gc_t::nat64stateful_remove_state(const dataplane::globalBase::nat64s
 {
 	/// remove on other numas
 	for (unsigned int numa_i = 0;
-	     numa_i < YANET_CONFIG_NUMA_SIZE;
+	     numa_i < base_permanently.activeNumaNodesCount;
 	     numa_i++)
 	{
 		auto* globalbase_atomic = base_permanently.globalBaseAtomics[numa_i];
@@ -1097,7 +1097,7 @@ void worker_gc_t::nat64stateful_state(const common::idp::nat64stateful_state::re
 
 			/// check other wan tables
 			for (unsigned int numa_i = 0;
-			     numa_i < YANET_CONFIG_NUMA_SIZE;
+			     numa_i < base_permanently.activeNumaNodesCount;
 			     numa_i++)
 			{
 				auto* globalbase_atomic = base_permanently.globalBaseAtomics[numa_i];
@@ -1132,7 +1132,7 @@ void worker_gc_t::nat64stateful_state(const common::idp::nat64stateful_state::re
 
 			/// check lan tables
 			for (unsigned int numa_i = 0;
-			     numa_i < YANET_CONFIG_NUMA_SIZE;
+			     numa_i < base_permanently.activeNumaNodesCount;
 			     numa_i++)
 			{
 				auto* globalbase_atomic = base_permanently.globalBaseAtomics[numa_i];


### PR DESCRIPTION
The issue was in `cDataPlane::initWorkers`, which performed a check: `if (socket_id >= dataPlane->globalBaseAtomics.size())`.

The old code incorrectly assumed that NUMA node IDs would always be sequential. It failed in setups where workers were only on node 1, for example: All workers are moved to NUMA socket 1, leaving socket 0 with no workers. `globalBaseAtomics` map contains only one entry: `{1: <ptr>}`. Its size is 1. When a worker on socket 1 initializes, the check becomes `if (1 >= 1)`

Now `base::permanently` has a member that stores the actual number of NUMA nodes that have active workers. All loops in `worker.cpp` and `worker_gc.cpp` that previously iterated up to `YANET_CONFIG_NUMA_SIZE` now use that value.