### PR TITLE
Add per logicalPort metrics

### DIFF
--- a/cli/bus.h
+++ b/cli/bus.h
@@ -24,6 +24,7 @@ inline std::vector<bus_request_info> get_bus_requests(common::sdp::DataPlaneInSh
 	        {common::idp::requestType::get_dregress_counters, "get_dregress_counters"},
 	        {common::idp::requestType::get_ports_stats, "get_ports_stats"},
 	        {common::idp::requestType::get_ports_stats_extended, "get_ports_stats_extended"},
+	        {common::idp::requestType::get_logical_ports_stats, "get_logical_ports_stats"},
 	        {common::idp::requestType::getControlPlanePortStats, "getControlPlanePortStats"},
 	        {common::idp::requestType::getPortStatsEx, "getPortStatsEx"},
 	        {common::idp::requestType::getFragmentationStats, "getFragmentationStats"},

--- a/cli/show.h
+++ b/cli/show.h
@@ -87,7 +87,11 @@ inline void logicalPort()
 	                 "vlanId",
 	                 "vrf",
 	                 "macAddress",
-	                 "promiscuousMode");
+	                 "promiscuousMode",
+	                 "rx_packets",
+	                 "rx_bytes",
+	                 "tx_packets",
+	                 "tx_bytes");
 
 	for (const auto& [logicalPortName, logicalPort] : response)
 	{
@@ -96,7 +100,11 @@ inline void logicalPort()
 		                 std::get<1>(logicalPort),
 		                 std::get<2>(logicalPort),
 		                 std::get<3>(logicalPort),
-		                 std::get<4>(logicalPort) ? "true" : "false");
+		                 std::get<4>(logicalPort) ? "true" : "false",
+		                 std::get<5>(logicalPort),
+		                 std::get<6>(logicalPort),
+		                 std::get<7>(logicalPort),
+		                 std::get<8>(logicalPort));
 	}
 
 	table.Print();

--- a/cli/telegraf.h
+++ b/cli/telegraf.h
@@ -589,7 +589,7 @@ void dregress_traffic()
 void other()
 {
 	interface::controlPlane controlPlane;
-	const auto& [flagFirst, workers, ports] = controlPlane.telegraf_other();
+	const auto& [flagFirst, workers, ports, logicalPorts] = controlPlane.telegraf_other();
 	const auto rib_summary = controlPlane.rib_summary();
 	const auto limit_summary = controlPlane.limit_summary();
 	GCC_BUG_UNUSED(flagFirst);
@@ -605,6 +605,13 @@ void other()
 	{
 		influxdb_format::print("port",
 		                       {{"physicalPortName", physicalPortName}},
+		                       {{"ext_", stats}});
+	}
+
+	for (const auto& [logicalPortName, stats] : logicalPorts)
+	{
+		influxdb_format::print("logicalPort",
+		                       {{"logicalPortName", logicalPortName}},
 		                       {{"ext_", stats}});
 	}
 

--- a/common/icp.h
+++ b/common/icp.h
@@ -320,11 +320,15 @@ using worker = std::tuple<double>; ///< usage
 
 using port = std::map<std::string, uint64>; ///< all stats
 
+using logicalPort = std::map<std::string, uint64_t>;	///< stats
+
 using response = std::tuple<uint8_t, ///< flagFirst
                             std::map<coreId,
                                      worker>,
                             std::map<std::string,
-                                     port>>;
+                                     port>,
+			    std::map<std::string,
+				     logicalPort>>;
 }
 
 namespace telegraf_mappings
@@ -355,11 +359,15 @@ using response = std::map<std::string,
 namespace getLogicalPorts
 {
 using response = std::map<std::string,
-                          std::tuple<std::string, ///< physicalPortName
-                                     uint16_t, ///< vlanId
-                                     std::string, ///< vrf
-                                     mac_address_t, ///< macAddress
-                                     uint8_t>>; ///< promiscuousMode
+                          std::tuple<std::string,       ///< physicalPortName
+                                     uint16_t,          ///< vlanId
+                                     std::string,       ///< vrf
+                                     mac_address_t,     ///< macAddress
+                                     uint8_t,           ///< promiscuousMode
+                                     uint64_t,          ///< rx_packets
+                                     uint64_t,          ///< rx_bytes
+                                     uint64_t,          ///< tx_packets
+                                     uint64_t>>;        ///< tx_bytes
 }
 
 namespace tun64_tunnels

--- a/common/idataplane.h
+++ b/common/idataplane.h
@@ -75,6 +75,11 @@ public:
 		return get<common::idp::requestType::get_ports_stats_extended, common::idp::get_ports_stats_extended::response>();
 	}
 
+	common::idp::get_logical_ports_stats::response get_logical_ports_stats() const
+	{
+		return get<common::idp::requestType::get_logical_ports_stats, common::idp::get_logical_ports_stats::response>();
+	}
+
 	common::idp::getControlPlanePortStats::response getControlPlanePortStats(const common::idp::getControlPlanePortStats::request& request) const
 	{
 		return get<common::idp::requestType::getControlPlanePortStats, common::idp::getControlPlanePortStats::response>(request);

--- a/common/idp.h
+++ b/common/idp.h
@@ -45,6 +45,7 @@ enum class requestType : uint32_t
 	get_dregress_counters,
 	get_ports_stats,
 	get_ports_stats_extended,
+	get_logical_ports_stats,
 	getControlPlanePortStats,
 	getPortStatsEx,
 	getFragmentationStats,
@@ -104,6 +105,12 @@ using port_stats_t = std::map<tPortId,
                                          uint64_t, ///< tx_bytes
                                          uint64_t, ///< tx_errors
                                          uint64_t>>; ///< tx_drops
+                                                     ///
+using logical_port_stats_t = std::tuple<
+                                uint64_t,       // rx_packets
+                                uint64_t,       // rx_bytes
+                                uint64_t,       // tx_packets
+                                uint64_t>;      // tx_bytes
 
 namespace lpm
 {
@@ -683,6 +690,11 @@ using response = std::map<tPortId,
                           std::map<std::string, common::uint64>>; ///< all stats
 }
 
+namespace get_logical_ports_stats
+{
+using response = std::map<tLogicalPortId, common::idp::logical_port_stats_t>;
+}
+
 namespace getControlPlanePortStats
 {
 using request = std::set<tPortId>;
@@ -1047,6 +1059,7 @@ using response = std::variant<std::tuple<>,
                               get_dregress_counters::response,
                               get_ports_stats::response, ///< + getControlPlanePortStats::response
                               get_ports_stats_extended::response,
+                              get_logical_ports_stats::response,
                               getPortStatsEx::response,
                               getFragmentationStats::response,
                               getFWState::response,

--- a/common/sdpclient.h
+++ b/common/sdpclient.h
@@ -352,21 +352,22 @@ private:
 			}
 			uint64_t index = start_workers_metadata / sizeof(uint64_t);
 
-			// 0-5 - values from MetadataWorker
+			// 0-6 - values from MetadataWorker
 			sdp_data.metadata_worker.start_counters = ReadValue(buffer, index);
 			sdp_data.metadata_worker.start_acl_counters = ReadValue(buffer, index + 1);
 			sdp_data.metadata_worker.start_bursts = ReadValue(buffer, index + 2);
 			sdp_data.metadata_worker.start_stats = ReadValue(buffer, index + 3);
 			sdp_data.metadata_worker.start_stats_ports = ReadValue(buffer, index + 4);
-			sdp_data.metadata_worker.size = ReadValue(buffer, index + 5);
-			// 6 - n1 = size MetadataWorker.counter_positions
-			uint64_t n1 = ReadValue(buffer, index + 6);
-			// 7-9 - values from MetadataWorker
-			sdp_data.metadata_worker_gc.start_counters = ReadValue(buffer, index + 7);
-			sdp_data.metadata_worker_gc.start_stats = ReadValue(buffer, index + 8);
-			sdp_data.metadata_worker_gc.size = ReadValue(buffer, index + 9);
-			// 10 - n2 = size MetadataWorker.counter_positions
-			uint64_t n2 = ReadValue(buffer, index + 10);
+			sdp_data.metadata_worker.start_stats_logical_ports = ReadValue(buffer, index + 5);
+			sdp_data.metadata_worker.size = ReadValue(buffer, index + 6);
+			// 7 - n1 = size MetadataWorker.counter_positions
+			uint64_t n1 = ReadValue(buffer, index + 7);
+			// 8-10 - values from MetadataWorker
+			sdp_data.metadata_worker_gc.start_counters = ReadValue(buffer, index + 8);
+			sdp_data.metadata_worker_gc.start_stats = ReadValue(buffer, index + 9);
+			sdp_data.metadata_worker_gc.size = ReadValue(buffer, index + 10);
+			// 11 - n2 = size MetadataWorker.counter_positions
+			uint64_t n2 = ReadValue(buffer, index + 11);
 
 			if (128 * (1 + n1 + n2) > size_workers_metadata)
 			{

--- a/common/sdpcommon.h
+++ b/common/sdpcommon.h
@@ -117,6 +117,7 @@ struct MetadataWorker
 	uint64_t start_bursts;
 	uint64_t start_stats;
 	uint64_t start_stats_ports;
+	uint64_t start_stats_logical_ports;
 	uint64_t size;
 
 	std::map<std::string, uint64_t> counter_positions;
@@ -128,6 +129,7 @@ struct MetadataWorker
 		       other.start_bursts == start_bursts &&
 		       other.start_stats == start_stats &&
 		       other.start_stats_ports == start_stats_ports &&
+		       other.start_stats_logical_ports == start_stats_logical_ports &&
 		       other.size == size &&
 		       MapsEqual(other.counter_positions, counter_positions);
 	}

--- a/common/type.h
+++ b/common/type.h
@@ -1932,6 +1932,14 @@ struct port
 	uint64_t physicalPort_egress_drops = 0;
 	uint64_t controlPlane_drops = 0; ///< @todo: DELETE
 };
+
+struct logicalPort
+{
+	uint64_t rx_packets = 0;
+	uint64_t rx_bytes = 0;
+	uint64_t tx_packets = 0;
+	uint64_t tx_bytes = 0;
+};
 }
 
 namespace worker_gc

--- a/controlplane/controlplane.cpp
+++ b/controlplane/controlplane.cpp
@@ -308,16 +308,22 @@ common::icp::getPhysicalPorts::response cControlPlane::getPhysicalPorts() const
 common::icp::getLogicalPorts::response cControlPlane::getLogicalPorts() const
 {
 	common::icp::getLogicalPorts::response response;
+	auto logicalPortsStats = dataPlane.get_logical_ports_stats();
 
 	{
 		auto current_guard = generations.current_lock_guard();
 		for (const auto& [logicalPortName, logicalPort] : generations.current().logicalPorts)
 		{
+			auto stats = logicalPortsStats[logicalPort.logicalPortId];
 			response[logicalPortName] = {logicalPort.physicalPort,
 			                             logicalPort.vlanId,
 			                             logicalPort.vrf,
 			                             logicalPort.macAddress,
-			                             logicalPort.promiscuousMode};
+			                             logicalPort.promiscuousMode,
+			                             std::get<0>(stats),
+			                             std::get<1>(stats),
+			                             std::get<2>(stats),
+			                             std::get<3>(stats)};
 		}
 	}
 

--- a/controlplane/telegraf.cpp
+++ b/controlplane/telegraf.cpp
@@ -311,10 +311,12 @@ common::icp::telegraf_other::response telegraf_t::telegraf_other()
 
 	const auto portsStatsExtended = dataPlane.get_ports_stats_extended();
 
+	const auto logicalPorts = controlPlane->getLogicalPorts();
+
 	//
 
 	common::icp::telegraf_other::response response;
-	auto& [response_flagFirst, response_workers, response_ports] = response;
+	auto& [response_flagFirst, response_workers, response_ports, response_logicalPorts] = response;
 
 	response_flagFirst = flagFirst;
 
@@ -340,6 +342,14 @@ common::icp::telegraf_other::response telegraf_t::telegraf_other()
 		}
 
 		response_ports[physicalPortName] = stats;
+	}
+
+	for (const auto& [logicalPortName, stats] : logicalPorts)
+	{
+		response_logicalPorts[logicalPortName]["rx_packets"] = std::get<5>(stats);
+		response_logicalPorts[logicalPortName]["rx_bytes"] = std::get<6>(stats);
+		response_logicalPorts[logicalPortName]["tx_packets"] = std::get<7>(stats);
+		response_logicalPorts[logicalPortName]["tx_bytes"] = std::get<8>(stats);
 	}
 
 	//

--- a/dataplane/bus.cpp
+++ b/dataplane/bus.cpp
@@ -206,6 +206,10 @@ void cBus::clientThread(int clientSocket)
 		{
 			response = callWithResponse(&cControlPlane::get_ports_stats_extended, request);
 		}
+		else if (type == common::idp::requestType::get_logical_ports_stats)
+		{
+			response = callWithResponse(&cControlPlane::get_logical_ports_stats, request);
+		}
 		else if (type == common::idp::requestType::getControlPlanePortStats)
 		{
 			response = callWithResponse(&cControlPlane::getControlPlanePortStats, request);

--- a/dataplane/controlplane.cpp
+++ b/dataplane/controlplane.cpp
@@ -377,7 +377,12 @@ std::set<tLogicalPortId> cControlPlane::getActiveLogicalPorts()
 {
 	std::lock_guard<std::mutex> guard(mutex);
 
-    std::set<tLogicalPortId> result;
+	return _getActiveLogicalPorts();
+}
+
+std::set<tLogicalPortId> cControlPlane::_getActiveLogicalPorts()
+{
+        std::set<tLogicalPortId> result;
 
 	if (dataPlane->globalBases.empty())
 	{

--- a/dataplane/controlplane.cpp
+++ b/dataplane/controlplane.cpp
@@ -373,6 +373,64 @@ common::idp::get_ports_stats_extended::response cControlPlane::get_ports_stats_e
 	return response;
 }
 
+std::set<tLogicalPortId> cControlPlane::getActiveLogicalPorts()
+{
+	std::lock_guard<std::mutex> guard(mutex);
+
+    std::set<tLogicalPortId> result;
+
+	if (dataPlane->globalBases.empty())
+	{
+		return result;
+	}
+
+	const auto* globalBase = dataPlane->globalBases.begin()->second[dataPlane->currentGlobalBaseId];
+	if (globalBase == nullptr)
+	{
+		return result;
+	}
+
+	for (uint32_t logicalPortId = 0;
+	     logicalPortId < CONFIG_YADECAP_LOGICALPORTS_SIZE;
+	     ++logicalPortId)
+	{
+		const auto& logicalPort = globalBase->logicalPorts[logicalPortId];
+		if (logicalPort.flow.type == common::globalBase::eFlowType::controlPlane)
+		{
+			continue;
+		}
+
+		result.emplace(logicalPortId);
+	}
+
+	return result;
+}
+
+common::idp::get_logical_ports_stats::response cControlPlane::get_logical_ports_stats()
+{
+	common::idp::get_logical_ports_stats::response response;
+	std::set<tLogicalPortId> activeLogicalPorts = getActiveLogicalPorts();
+
+	for (const auto& logicalPortId : activeLogicalPorts)
+	{
+		common::idp::logical_port_stats_t stats = std::accumulate(
+		        workers_vector().begin(),
+		        workers_vector().end(),
+                common::idp::logical_port_stats_t{},
+		        [logicalPortId](common::idp::logical_port_stats_t total, cWorker* worker) {
+			        std::get<0>(total) += worker->statsLogicalPorts[logicalPortId].rx_packets;
+			        std::get<1>(total) += worker->statsLogicalPorts[logicalPortId].rx_bytes;
+			        std::get<2>(total) += worker->statsLogicalPorts[logicalPortId].tx_packets;
+			        std::get<3>(total) += worker->statsLogicalPorts[logicalPortId].tx_bytes;
+			        return total;
+		        });
+
+		response[logicalPortId] = stats;
+	}
+
+	return response;
+}
+
 common::idp::getControlPlanePortStats::response cControlPlane::getControlPlanePortStats(const common::idp::getControlPlanePortStats::request& request)
 {
 	/// unsafe

--- a/dataplane/controlplane.h
+++ b/dataplane/controlplane.h
@@ -53,6 +53,7 @@ public:
 	common::idp::get_dregress_counters::response get_dregress_counters();
 	common::idp::get_ports_stats::response get_ports_stats();
 	common::idp::get_ports_stats_extended::response get_ports_stats_extended();
+	common::idp::get_logical_ports_stats::response get_logical_ports_stats();
 	common::idp::getControlPlanePortStats::response getControlPlanePortStats(const common::idp::getControlPlanePortStats::request& request);
 	common::idp::getPortStatsEx::response getPortStatsEx();
 	[[nodiscard]] common::idp::getFragmentationStats::response getFragmentationStats() const;
@@ -92,6 +93,7 @@ public:
 private:
 	[[nodiscard]] const std::vector<cWorker*>& workers_vector() const;
 	[[nodiscard]] const std::map<tCoreId, dataplane::SlowWorker*>& slow_workers() const;
+	[[nodiscard]] std::set<tLogicalPortId> getActiveLogicalPorts();
 
 	template<typename F>
 	// @brief returns sum of results of applying F to all cWorker*s

--- a/dataplane/controlplane.h
+++ b/dataplane/controlplane.h
@@ -93,6 +93,7 @@ public:
 private:
 	[[nodiscard]] const std::vector<cWorker*>& workers_vector() const;
 	[[nodiscard]] const std::map<tCoreId, dataplane::SlowWorker*>& slow_workers() const;
+	[[nodiscard]] std::set<tLogicalPortId> _getActiveLogicalPorts();
 	[[nodiscard]] std::set<tLogicalPortId> getActiveLogicalPorts();
 
 	template<typename F>

--- a/dataplane/report.cpp
+++ b/dataplane/report.cpp
@@ -65,10 +65,11 @@ cReport::cReport(cDataPlane* dataPlane) :
 nlohmann::json cReport::getReport()
 {
 	nlohmann::json jsonReport;
+	const auto activeLogicalPorts = dataPlane->controlPlane->_getActiveLogicalPorts();
 
 	for (const cWorker* worker : dataPlane->workers_vector)
 	{
-		jsonReport["workers"].emplace_back(convertWorker(worker));
+		jsonReport["workers"].emplace_back(convertWorker(worker, activeLogicalPorts));
 	}
 
 	for (const auto& [core_id, worker] : dataPlane->worker_gcs)
@@ -126,7 +127,7 @@ static inline std::string convertEtherAddressToString(const rte_ether_addr& ethe
 	return buffer;
 }
 
-nlohmann::json cReport::convertWorker(const cWorker* worker)
+nlohmann::json cReport::convertWorker(const cWorker* worker, const std::set<tLogicalPortId>& activeLogicalPorts)
 {
 	nlohmann::json json;
 
@@ -180,6 +181,19 @@ nlohmann::json cReport::convertWorker(const cWorker* worker)
 		jsonPort["controlPlane_drops"] = 0; // @todo: DELETE
 
 		json["statsPorts"].emplace_back(jsonPort);
+	}
+
+	for (const auto logicalPortId : activeLogicalPorts)
+	{
+		nlohmann::json jsonLogicalPort;
+
+		jsonLogicalPort["logicalPortId"] = logicalPortId;
+		jsonLogicalPort["rx_packets"] = worker->statsLogicalPorts[logicalPortId].rx_packets;
+		jsonLogicalPort["rx_bytes"] = worker->statsLogicalPorts[logicalPortId].rx_bytes;
+		jsonLogicalPort["tx_packets"] = worker->statsLogicalPorts[logicalPortId].tx_packets;
+		jsonLogicalPort["tx_bytes"] = worker->statsLogicalPorts[logicalPortId].tx_bytes;
+
+		json["statsLogicalPorts"].emplace_back(jsonLogicalPort);
 	}
 
 	for (unsigned int burst_i = 0;

--- a/dataplane/report.h
+++ b/dataplane/report.h
@@ -21,7 +21,7 @@ public:
 	nlohmann::json getReport();
 
 protected:
-	nlohmann::json convertWorker(const cWorker* worker);
+	nlohmann::json convertWorker(const cWorker* worker, const std::set<tLogicalPortId>& activeLogicalPorts);
 	nlohmann::json convertWorkerGC(const worker_gc_t* worker);
 	nlohmann::json convertMempool(const rte_mempool* mempool);
 	nlohmann::json convertPort(const tPortId& portId);

--- a/dataplane/sdpserver.h
+++ b/dataplane/sdpserver.h
@@ -166,21 +166,22 @@ private:
 		{
 			uint64_t index = start_workers_metadata / sizeof(uint64_t);
 
-			// 0-5 - values from MetadataWorker
+			// 0-6 - values from MetadataWorker
 			WriteValue(sdp_data, index, sdp_data.metadata_worker.start_counters);
 			WriteValue(sdp_data, index + 1, sdp_data.metadata_worker.start_acl_counters);
 			WriteValue(sdp_data, index + 2, sdp_data.metadata_worker.start_bursts);
 			WriteValue(sdp_data, index + 3, sdp_data.metadata_worker.start_stats);
 			WriteValue(sdp_data, index + 4, sdp_data.metadata_worker.start_stats_ports);
-			WriteValue(sdp_data, index + 5, sdp_data.metadata_worker.size);
-			// 6 - n1 = size MetadataWorker.counter_positions
-			WriteValue(sdp_data, index + 6, sdp_data.metadata_worker.counter_positions.size());
-			// 7-9 - values from MetadataWorker
-			WriteValue(sdp_data, index + 7, sdp_data.metadata_worker_gc.start_counters);
-			WriteValue(sdp_data, index + 8, sdp_data.metadata_worker_gc.start_stats);
-			WriteValue(sdp_data, index + 9, sdp_data.metadata_worker_gc.size);
-			// 10 - n2 = size MetadataWorker.counter_positions
-			WriteValue(sdp_data, index + 10, sdp_data.metadata_worker_gc.counter_positions.size());
+			WriteValue(sdp_data, index + 5, sdp_data.metadata_worker.start_stats_logical_ports);
+			WriteValue(sdp_data, index + 6, sdp_data.metadata_worker.size);
+			// 7 - n1 = size MetadataWorker.counter_positions
+			WriteValue(sdp_data, index + 7, sdp_data.metadata_worker.counter_positions.size());
+			// 8-10 - values from MetadataWorker
+			WriteValue(sdp_data, index + 8, sdp_data.metadata_worker_gc.start_counters);
+			WriteValue(sdp_data, index + 9, sdp_data.metadata_worker_gc.start_stats);
+			WriteValue(sdp_data, index + 10, sdp_data.metadata_worker_gc.size);
+			// 11 - n2 = size MetadataWorker.counter_positions
+			WriteValue(sdp_data, index + 11, sdp_data.metadata_worker_gc.counter_positions.size());
 
 			WriteMap(sdp_data, start_workers_metadata + 128, sdp_data.metadata_worker.counter_positions);
 			WriteMap(sdp_data, start_workers_metadata + 128 * (1 + sdp_data.metadata_worker.counter_positions.size()), sdp_data.metadata_worker_gc.counter_positions);

--- a/dataplane/unittest/sdp.cpp
+++ b/dataplane/unittest/sdp.cpp
@@ -77,6 +77,8 @@ public:
 		metadata.start_bursts = common::sdp::SdrSever::GetStartData((CONFIG_YADECAP_MBUFS_BURST_SIZE + 1) * sizeof(uint64_t), metadata.size);
 		metadata.start_stats = common::sdp::SdrSever::GetStartData(sizeof(common::worker::stats::common), metadata.size);
 		metadata.start_stats_ports = common::sdp::SdrSever::GetStartData(sizeof(common::worker::stats::port[CONFIG_YADECAP_PORTS_SIZE]), metadata.size);
+		metadata.start_stats_logical_ports =
+		        common::sdp::SdrSever::GetStartData(sizeof(common::worker::stats::logicalPort[CONFIG_YADECAP_LOGICALPORTS_SIZE]), metadata.size);
 
 		// stats
 		std::map<std::string, uint64_t> counters_stats;
@@ -166,6 +168,7 @@ public:
 		bursts = utils::ShiftBuffer<uint64_t*>(buffer, metadata.start_bursts);
 		stats = utils::ShiftBuffer<common::worker::stats::common*>(buffer, metadata.start_stats);
 		statsPorts = utils::ShiftBuffer<common::worker::stats::port*>(buffer, metadata.start_stats_ports);
+		statsLogicalPorts = utils::ShiftBuffer<common::worker::stats::logicalPort*>(buffer, metadata.start_stats_logical_ports);
 	}
 
 	void SetTestValues(tCoreId coreId)
@@ -180,22 +183,31 @@ public:
 			statsPorts[index].physicalPort_egress_drops = 4 * (index + coreId);
 		}
 
+		// statsLogicalPorts
+		for (uint32_t index = 0; index < CONFIG_YADECAP_LOGICALPORTS_SIZE; index++)
+		{
+			statsLogicalPorts[index].rx_packets = 5 * (index + coreId);
+			statsLogicalPorts[index].rx_bytes = 6 * (index + coreId);
+			statsLogicalPorts[index].tx_packets = 7 * (index + coreId);
+			statsLogicalPorts[index].tx_bytes = 8 * (index + coreId);
+		}
+
 		// bursts
 		for (uint32_t index = 0; index < CONFIG_YADECAP_MBUFS_BURST_SIZE + 1; index++)
 		{
-			bursts[index] = 5 * (index + coreId);
+			bursts[index] = 9 * (index + coreId);
 		}
 
 		// counters
 		for (uint32_t index = YANET_CONFIG_COUNTER_FALLBACK_SIZE; index < YANET_CONFIG_COUNTERS_SIZE; index++)
 		{
-			counters[index] = (index + coreId) * (index + coreId);
+			counters[index] = 10 * (index + coreId) * (index + coreId);
 		}
 
 		// aclCounters
 		for (uint32_t index = 0; index < YANET_CONFIG_ACL_COUNTERS_SIZE; index++)
 		{
-			aclCounters[index] = index + coreId;
+			aclCounters[index] = 11 * (index + coreId);
 		}
 	}
 
@@ -214,6 +226,17 @@ public:
 		{
 			ASSERT_EQ(statsPorts[index].controlPlane_drops, bufStatsPorts[index].controlPlane_drops);
 			ASSERT_EQ(statsPorts[index].physicalPort_egress_drops, bufStatsPorts[index].physicalPort_egress_drops);
+		}
+
+		// statsLogicalPorts
+		auto* bufStatsLogicalPorts =
+		        utils::ShiftBuffer<common::worker::stats::logicalPort*>(buffer, sdp_data_client.metadata_worker.start_stats_logical_ports);
+		for (uint32_t index = 0; index < CONFIG_YADECAP_LOGICALPORTS_SIZE; index++)
+		{
+			ASSERT_EQ(statsLogicalPorts[index].rx_packets, bufStatsLogicalPorts[index].rx_packets);
+			ASSERT_EQ(statsLogicalPorts[index].rx_bytes, bufStatsLogicalPorts[index].rx_bytes);
+			ASSERT_EQ(statsLogicalPorts[index].tx_packets, bufStatsLogicalPorts[index].tx_packets);
+			ASSERT_EQ(statsLogicalPorts[index].tx_bytes, bufStatsLogicalPorts[index].tx_bytes);
 		}
 
 		// bursts
@@ -241,6 +264,7 @@ public:
 protected:
 	common::worker::stats::common* stats;
 	common::worker::stats::port* statsPorts; // CONFIG_YADECAP_PORTS_SIZE
+	common::worker::stats::logicalPort* statsLogicalPorts; // CONFIG_YADECAP_LOGICALPORTS_SIZE
 	uint64_t* bursts; // CONFIG_YADECAP_MBUFS_BURST_SIZE + 1
 	uint64_t* counters; // YANET_CONFIG_COUNTERS_SIZE
 	uint64_t* aclCounters; // YANET_CONFIG_ACL_COUNTERS_SIZE

--- a/dataplane/worker.cpp
+++ b/dataplane/worker.cpp
@@ -354,6 +354,7 @@ void cWorker::SetBufferForCounters(void* buffer, const common::sdp::MetadataWork
 	bursts = utils::ShiftBuffer<uint64_t*>(buffer, metadata.start_bursts);
 	stats = utils::ShiftBuffer<common::worker::stats::common*>(buffer, metadata.start_stats);
 	statsPorts = utils::ShiftBuffer<common::worker::stats::port*>(buffer, metadata.start_stats_ports);
+	statsLogicalPorts = utils::ShiftBuffer<common::worker::stats::logicalPort*>(buffer, metadata.start_stats_logical_ports);
 }
 
 eResult cWorker::sanityCheck()
@@ -1197,6 +1198,10 @@ inline void cWorker::logicalPort_ingress_flow(rte_mbuf* mbuf,
 {
 	dataplane::metadata* metadata = YADECAP_METADATA(mbuf);
 	metadata->flow = flow;
+	auto logicalPortId = metadata->in_logicalport_id;
+
+	statsLogicalPorts[logicalPortId].rx_packets += 1;
+	statsLogicalPorts[logicalPortId].rx_bytes += mbuf->pkt_len;
 
 	if (flow.type == common::globalBase::eFlowType::acl_ingress)
 	{
@@ -1223,7 +1228,11 @@ inline void cWorker::logicalPort_ingress_flow(rte_mbuf* mbuf,
 inline void cWorker::logicalPort_egress_entry(rte_mbuf* mbuf)
 {
 	dataplane::metadata* metadata = YADECAP_METADATA(mbuf);
-	metadata->out_logicalport_id = metadata->flow.data.logicalPortId;
+	auto logicalPortId = metadata->flow.data.logicalPortId;
+	metadata->out_logicalport_id = logicalPortId;
+
+	statsLogicalPorts[logicalPortId].tx_packets += 1;
+	statsLogicalPorts[logicalPortId].tx_bytes += mbuf->pkt_len;
 
 	logicalPort_egress_stack.insert(mbuf);
 }

--- a/dataplane/worker.h
+++ b/dataplane/worker.h
@@ -403,6 +403,7 @@ protected:
 
 	common::worker::stats::common* stats;
 	common::worker::stats::port* statsPorts; // CONFIG_YADECAP_PORTS_SIZE
+	common::worker::stats::logicalPort* statsLogicalPorts; // CONFIG_YADECAP_LOGICALPORTS_SIZE
 	uint64_t* bursts; // CONFIG_YADECAP_MBUFS_BURST_SIZE + 1
 	uint64_t* counters; // YANET_CONFIG_COUNTERS_SIZE
 	uint64_t* aclCounters; // YANET_CONFIG_ACL_COUNTERS_SIZE


### PR DESCRIPTION
Hello,

This PR implements per logicalPort rx/tx packets/bytes metrics collection and reporting. The existing code patterns have been followed:
* per worker pre-allocated statsLogicalPorts array (adds ~2MB per worker)
* added metrics columns to yanet-cli logicalPort
* added logicalPort metrics to yanet-cli telegraf other and yanet-cli dontdoit podumoi dataplane report
* updated dataplane unittest

This contribution falls under the CLA between Nebius BV and Yandex LLC.

