### PR TITLE
dataplane: sync KNI interface MAC after port start

### DIFF
--- a/dataplane/dataplane.cpp
+++ b/dataplane/dataplane.cpp
@@ -39,6 +39,7 @@
 #include "common/utils.h"
 #include "dataplane.h"
 #include "dataplane/sdpserver.h"
+#include "dpdk.h"
 #include "dump_rings.h"
 #include "globalbase.h"
 #include "sock_dev.h"
@@ -707,11 +708,33 @@ void cDataPlane::StartInterfaces()
 	{
 		for (auto& [portid, handles] : kni_interface_handles)
 		{
+			// Read the actual MAC after rte_eth_dev_start(): for some drivers
+			// the MAC only becomes valid (or may change) once the port is started.
+			auto actual_mac = dpdk::GetMacAddress(portid);
+			if (!actual_mac)
+			{
+				YANET_LOG_ERROR("Failed to get MAC for port belonging to %s", std::get<0>(ports.at(portid)).c_str());
+				std::abort();
+			}
+
 			if (!handles.Start())
 			{
 				YANET_LOG_ERROR("Failed to start kni interfaces");
 				std::abort();
 			}
+
+			// Sync the actual MAC to all KNI interfaces, because it may differ
+			// from what was used at vdev creation time (before the port start).
+			// MAC must be changed while the interface is DOWN, hence before SetUp().
+			if (!handles.forward.SyncMac(*actual_mac) ||
+			    !handles.in_dump.SyncMac(*actual_mac) ||
+			    !handles.out_dump.SyncMac(*actual_mac) ||
+			    !handles.drop_dump.SyncMac(*actual_mac))
+			{
+				YANET_LOG_ERROR("Failed to sync MAC on kni interfaces belonging to %s", std::get<0>(ports.at(portid)).c_str());
+				std::abort();
+			}
+
 			if (!handles.forward.SetUp())
 			{
 				YANET_LOG_ERROR("Failed to set kni interface belonging to %s up", std::get<0>(ports.at(portid)).c_str());

--- a/dataplane/kernel_interface_handle.cpp
+++ b/dataplane/kernel_interface_handle.cpp
@@ -1,6 +1,8 @@
 #include <linux/if.h>
+#include <net/if_arp.h>
 #include <sys/ioctl.h>
 #include <sys/un.h>
+#include <unistd.h>
 
 #include <rte_ethdev.h>
 
@@ -8,6 +10,42 @@
 #include "kernel_interface_handle.h"
 namespace dataplane
 {
+
+bool KernelInterfaceHandle::SyncMac(const common::mac_address_t& addr) const noexcept
+{
+	// Skip zero/invalid MAC (e.g. sock_dev leaves it all-zeros). Setting a
+	// zero MAC via SIOCSIFHWADDR fails with EINVAL on most drivers.
+	if (addr.is_default())
+	{
+		YANET_LOG_WARNING("SyncMac: skipping zero MAC for interface %s\n", name_.data());
+		return true;
+	}
+
+	// NOTE: MAC must be changed while the interface is DOWN. This method is
+	// therefore expected to be called before SetUp() (which raises IFF_UP).
+	int sock = ::socket(AF_INET, SOCK_DGRAM, 0);
+	if (sock < 0)
+	{
+		YANET_LOG_ERROR("SyncMac: failed to open socket for interface %s\n", name_.data());
+		return false;
+	}
+
+	struct ifreq request;
+	memset(&request, 0, sizeof(request));
+	strncpy(request.ifr_name, name_.data(), IFNAMSIZ - 1);
+	request.ifr_hwaddr.sa_family = ARPHRD_ETHER;
+	memcpy(request.ifr_hwaddr.sa_data, addr.data(), RTE_ETHER_ADDR_LEN);
+
+	if (ioctl(sock, SIOCSIFHWADDR, &request) < 0)
+	{
+		YANET_LOG_ERROR("SyncMac: failed to set MAC on interface %s\n", name_.data());
+		::close(sock);
+		return false;
+	}
+
+	::close(sock);
+	return true;
+}
 
 bool KernelInterfaceHandle::SetUp() const noexcept
 {
@@ -20,14 +58,16 @@ bool KernelInterfaceHandle::SetUp() const noexcept
 	struct ifreq request;
 	memset(&request, 0, sizeof request);
 
-	strncpy(request.ifr_name, name_.data(), IFNAMSIZ);
+	strncpy(request.ifr_name, name_.data(), IFNAMSIZ - 1);
 
 	request.ifr_flags |= IFF_UP;
 	if (auto res = ioctl(socket, SIOCSIFFLAGS, &request))
 	{
 		YANET_LOG_ERROR("failed to set interface %s up, ioctl returned (%d)", name_.data(), res);
+		::close(socket);
 		return false;
 	}
+	::close(socket);
 	return true;
 }
 

--- a/dataplane/kernel_interface_handle.h
+++ b/dataplane/kernel_interface_handle.h
@@ -30,6 +30,7 @@ public:
 	[[nodiscard]] const tPortId& Id() const noexcept { return kni_port_; }
 	[[nodiscard]] bool Start() const noexcept;
 	[[nodiscard]] bool SetUp() const noexcept;
+	[[nodiscard]] bool SyncMac(const common::mac_address_t& addr) const noexcept;
 	bool SetupRxQueue(tQueueId queue, tSocketId socket, rte_mempool* mempool) noexcept;
 	bool SetupTxQueue(tQueueId queue, tSocketId socket) noexcept;
 	bool CloneMTU(const uint16_t) noexcept;


### PR DESCRIPTION
The KNI (virtio_user vdev) MAC address is baked into the vdev creation arguments at init_kernel_interfaces() time, which happens before the physical port is started. For some drivers the MAC is only valid (or may change) once rte_eth_dev_start() is called, which resulted in a mismatch: one MAC in yanet and a different one in the system after the interface was brought up.

Read the actual MAC via dpdk::GetMacAddress() after the port is started and apply it to all KNI interfaces (forward/in/out/drop) via SIOCSIFHWADDR while they are still DOWN, before SetUp() raises IFF_UP.

Also fix a pre-existing socket leak in SetUp() and harden interface name copying with IFNAMSIZ - 1.