### PR TITLE
Set kernel interface MAC address on setup

### DIFF
--- a/dataplane/kernel_interface_handle.cpp
+++ b/dataplane/kernel_interface_handle.cpp
@@ -1,4 +1,5 @@
 #include <linux/if.h>
+#include <linux/if_arp.h>
 #include <sys/ioctl.h>
 #include <sys/un.h>
 
@@ -21,6 +22,17 @@ bool KernelInterfaceHandle::SetUp() const noexcept
 	memset(&request, 0, sizeof request);
 
 	strncpy(request.ifr_name, name_.data(), IFNAMSIZ);
+
+	struct rte_ether_addr ether_addr;
+	rte_eth_macaddr_get(physical_port_, &ether_addr);
+	request.ifr_hwaddr.sa_family = ARPHRD_ETHER;
+	memcpy(request.ifr_hwaddr.sa_data, ether_addr.addr_bytes, RTE_ETHER_ADDR_LEN);
+	if (auto res = ioctl(socket, SIOCSIFHWADDR, &request))
+	{
+		YANET_LOG_ERROR("failed to set MAC address for interface %s, ioctl returned (%d)", name_.data(), res);
+		return false;
+	}
+	memset(&request.ifr_ifru, 0, sizeof request.ifr_ifru);
 
 	request.ifr_flags |= IFF_UP;
 	if (auto res = ioctl(socket, SIOCSIFFLAGS, &request))
@@ -61,6 +73,7 @@ KernelInterfaceHandle& KernelInterfaceHandle::operator=(KernelInterfaceHandle&& 
 	if (this != &other)
 	{
 		std::swap(kni_port_, other.kni_port_);
+		std::swap(physical_port_, other.physical_port_);
 		std::swap(name_, other.name_);
 		std::swap(vdev_name_, other.vdev_name_);
 		std::swap(queue_size_, other.queue_size_);
@@ -77,6 +90,7 @@ KernelInterfaceHandle::MakeKernelInterfaceHandle(
 {
 	KernelInterfaceHandle kni;
 	kni.queue_size_ = queue_size;
+	kni.physical_port_ = port;
 	kni.name_ = name;
 	kni.vdev_name_ = VdevName(name, port);
 	std::string vdev_args = VdevArgs(name, port, queue_count, queue_size);

--- a/dataplane/kernel_interface_handle.cpp
+++ b/dataplane/kernel_interface_handle.cpp
@@ -24,7 +24,11 @@ bool KernelInterfaceHandle::SetUp() const noexcept
 	strncpy(request.ifr_name, name_.data(), IFNAMSIZ);
 
 	struct rte_ether_addr ether_addr;
-	rte_eth_macaddr_get(physical_port_, &ether_addr);
+	if (auto res = rte_eth_macaddr_get(physical_port_, &ether_addr))
+	{
+		YANET_LOG_ERROR("failed to get MAC address for port %u, rte_eth_macaddr_get returned (%d)", physical_port_, res);
+		return false;
+	}
 	request.ifr_hwaddr.sa_family = ARPHRD_ETHER;
 	memcpy(request.ifr_hwaddr.sa_data, ether_addr.addr_bytes, RTE_ETHER_ADDR_LEN);
 	if (auto res = ioctl(socket, SIOCSIFHWADDR, &request))

--- a/dataplane/kernel_interface_handle.h
+++ b/dataplane/kernel_interface_handle.h
@@ -10,6 +10,7 @@ namespace dataplane
 class KernelInterfaceHandle
 {
 	tPortId kni_port_ = INVALID_PORT_ID;
+	tPortId physical_port_ = INVALID_PORT_ID;
 	std::string name_;
 	std::string vdev_name_;
 	uint16_t queue_size_ = 0;


### PR DESCRIPTION
## Problem

When using kernel (KNI) interfaces, the device MAC address is detected correctly
inside YANET, but the corresponding interface in the OS sometimes gets an
incorrect, random MAC address .

## Root cause

YANET does not use DPDK's `rte_kni`; kernel interfaces are created as
`virtio_user` vdevs over `/dev/vhost-net`. The physical port MAC is passed only
via the `mac=` vdev argument (see `KernelInterfaceHandle::VdevArgs`).

That argument only affects the DPDK (virtio front-end) side of the interface.
The OS-visible tap/vhost back-end is not guaranteed to inherit it, so the kernel
may assign a random, locally-administered MAC. This is why the problem is
intermittent.

## Fix

Explicitly set the hardware address of the kernel interface via
`ioctl(SIOCSIFHWADDR)` in `KernelInterfaceHandle::SetUp()`, using the MAC of the
physical port. This is done before bringing the interface up (`IFF_UP`), because
the kernel refuses to change the hardware address of a running interface.

The physical port id is now stored in `KernelInterfaceHandle` so it is available
at setup time.

## Notes

- The `ifr_ifru` union is cleared between the `SIOCSIFHWADDR` and `SIOCSIFFLAGS`
  calls so that MAC bytes do not leak into `ifr_flags`.
- Changes are limited to `dataplane/kernel_interface_handle.{cpp,h}` (+15 lines).