### PR TITLE
Fix neighbor flush during route reload

### DIFF
--- a/controlplane/route.cpp
+++ b/controlplane/route.cpp
@@ -867,6 +867,8 @@ void route_t::compile_interface(common::idp::updateGlobalBase::request& globalba
 			                                                                                interface.flow});
 		}
 	}
+
+	dataplane.neighbor_flush();
 }
 
 void route_t::limit(common::icp::limit_summary::response& limits) const


### PR DESCRIPTION
## Summary

Publish pending neighbor-table updates once route interface compilation has inserted all configured static IPv4 and IPv6 neighbors.

## Root cause

Commit `a5371a2` removed the synchronous flush from each `neighbor_insert()` call so neighbor changes could be batched. During a route reload, `neighbor_update_interfaces()` publishes the rebuilt neighbor table before `compile_interface()` re-inserts the configured static neighbors. Those inserts remained in the pending generation until the background flush.

The latched asynchronous reload in `049_balancer_reload` can send its packet burst during that window. The active worker neighbor table therefore has no resolved next hop, all packets are dropped, and the test reports a missing first packet.

## Fix

Call `neighbor_flush()` once at the end of `route_t::compile_interface()`, after all static neighbors have been inserted. This keeps the batching behavior while ensuring the completed neighbor batch is visible before route reload compilation proceeds.

## Impact

Static neighbors are available synchronously at the route reload boundary, preventing transient packet loss during reload without restoring a full generation switch for every individual neighbor update.

## Validation

- `git diff --check`
- `python3 -m py_compile autotest/yanet-autotest-run.py`
- Focused runner invocation was attempted, but this workspace cannot execute YANET autotests because `/run/yanet` is not writable and it has no Docker/Podman, Meson, Ninja, C++ compiler, or prebuilt YANET binaries.

Recommended CI coverage:

```bash
yanet-autotest-run.py autotest/units/001_one_port autotest/units/001_one_port/049_balancer_reload
yanet-autotest-run.py autotest/units/001_one_port
```
